### PR TITLE
Fix missing localizations and imports

### DIFF
--- a/lib/domain/usecases/production_order_usecases.dart
+++ b/lib/domain/usecases/production_order_usecases.dart
@@ -325,4 +325,8 @@ class ProductionOrderUseCases {
   Stream<List<ProductModel>> getProductsForSelection() {
     return repository.getProducts();
   }
+
+  Future<ProductModel?> getProductById(String productId) {
+    return repository.getProductById(productId);
+  }
 }

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -234,5 +234,7 @@
   "orderFulfilledSuccessfully": "تم تحديد الطلب كمورد بنجاح!",
   "errorFulfillingOrder": "حدث خطأ أثناء تحديد الطلب كمورد",
   "salesRepresentative": "مندوب المبيعات",
+  "salesOrders": "طلبات المبيعات",
+  "salesOrder": "طلب مبيعات",
   "quantityUnit": "كمية"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -234,5 +234,7 @@
   "orderFulfilledSuccessfully": "تم تحديد الطلب كمورد بنجاح!",
   "errorFulfillingOrder": "حدث خطأ أثناء تحديد الطلب كمورد",
   "salesRepresentative": "مندوب المبيعات",
+  "salesOrders": "Sales Orders",
+  "salesOrder": "Sales Order",
   "quantityUnit": "كمية"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -248,6 +248,8 @@ class AppLocalizations {
   String get fulfill => _strings["fulfill"] ?? "fulfill";
   String get orderFulfilledSuccessfully => _strings["orderFulfilledSuccessfully"] ?? "orderFulfilledSuccessfully";
   String get errorFulfillingOrder => _strings["errorFulfillingOrder"] ?? "errorFulfillingOrder";
+  String get salesOrders => _strings["salesOrders"] ?? "salesOrders";
+  String get salesOrder => _strings["salesOrder"] ?? "salesOrder";
   String get quantityUnit => _strings["quantityUnit"] ?? "quantityUnit";
 }
 

--- a/lib/presentation/machinery/machine_profiles_screen.dart
+++ b/lib/presentation/machinery/machine_profiles_screen.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:plastic_factory_management/l10n/app_localizations.dart';
 import 'package:plastic_factory_management/data/models/machine_model.dart';
 import 'package:plastic_factory_management/domain/usecases/machinery_operator_usecases.dart';
+import 'package:intl/intl.dart' as intl;
 
 class MachineProfilesScreen extends StatefulWidget {
   @override


### PR DESCRIPTION
## Summary
- add `salesOrders` and `salesOrder` strings to ARB files
- expose `salesOrders` and `salesOrder` getters
- add missing import for intl in machine profile screen
- expose `getProductById` in production order use cases

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_684866947494832aade4d36b55abdea5