### PR TITLE
Implement quick sign-in

### DIFF
--- a/lib/core/services/auth_service.dart
+++ b/lib/core/services/auth_service.dart
@@ -36,6 +36,25 @@ class AuthService {
     }
   }
 
+  /// Attempts to sign in. If the user does not exist, a new account is created
+  /// automatically using a default name and [UserRole.unknown].
+  Future<UserModel> signInOrCreate(String email, String password) async {
+    try {
+      return await signInWithEmailPassword(email, password);
+    } on FirebaseAuthException catch (e) {
+      if (e.code == 'user-not-found') {
+        final defaultName = email.split('@').first;
+        return await signUpWithEmailPassword(
+          email,
+          password,
+          defaultName,
+          UserRole.unknown,
+        );
+      }
+      rethrow;
+    }
+  }
+
   // تسجيل مستخدم جديد (قد يستخدمه المدير لإنشاء حسابات)
   Future<UserModel> signUpWithEmailPassword(String email, String password, String name, UserRole role) async {
     try {

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -4,6 +4,7 @@
   "emailHint": "البريد الإلكتروني",
   "passwordHint": "كلمة المرور",
   "signInButton": "تسجيل الدخول",
+  "quickSignInButton": "تسجيل سريع",
   "loginErrorGeneric": "حدث خطأ غير متوقع. يرجى المحاولة مرة أخرى.",
   "factoryManager": "مدير المصنع",
   "productionManager": "مدير الإنتاج",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4,6 +4,7 @@
   "emailHint": "البريد الإلكتروني",
   "passwordHint": "كلمة المرور",
   "signInButton": "تسجيل الدخول",
+  "quickSignInButton": "تسجيل سريع",
   "loginErrorGeneric": "حدث خطأ غير متوقع. يرجى المحاولة مرة أخرى.",
   "factoryManager": "مدير المصنع",
   "productionManager": "مدير الإنتاج",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -19,6 +19,7 @@ class AppLocalizations {
   String get emailHint => _strings["emailHint"] ?? "emailHint";
   String get passwordHint => _strings["passwordHint"] ?? "passwordHint";
   String get signInButton => _strings["signInButton"] ?? "signInButton";
+  String get quickSignInButton => _strings["quickSignInButton"] ?? "quickSignInButton";
   String get loginErrorGeneric => _strings["loginErrorGeneric"] ?? "loginErrorGeneric";
   String get factoryManager => _strings["factoryManager"] ?? "factoryManager";
   String get productionManager => _strings["productionManager"] ?? "productionManager";

--- a/lib/presentation/auth/login_screen.dart
+++ b/lib/presentation/auth/login_screen.dart
@@ -48,6 +48,36 @@ class _LoginScreenState extends State<LoginScreen> {
     }
   }
 
+  Future<void> _quickSignIn() async {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+    try {
+      await _authService.signInOrCreate(
+        _emailController.text,
+        _passwordController.text,
+      );
+      if (mounted) {
+        Navigator.of(context).pushReplacementNamed(AppRouter.homeRoute);
+      }
+    } on FirebaseAuthException catch (e) {
+      setState(() {
+        _errorMessage = e.message;
+      });
+    } catch (e) {
+      setState(() {
+        _errorMessage = AppLocalizations.of(context)!.loginErrorGeneric;
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
   @override
   void dispose() {
     _emailController.dispose();
@@ -114,21 +144,45 @@ class _LoginScreenState extends State<LoginScreen> {
                 ),
               _isLoading
                   ? CircularProgressIndicator()
-                  : ElevatedButton(
-                onPressed: _signIn,
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Theme.of(context).primaryColor, // لون أساسي جميل
-                  foregroundColor: Colors.white,
-                  minimumSize: Size(double.infinity, 55), // زر بعرض كامل وارتفاع مناسب
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(8.0),
-                  ),
-                ),
-                child: Text(
-                  appLocalizations.signInButton,
-                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-                ),
-              ),
+                  : Column(
+                      children: [
+                        ElevatedButton(
+                          onPressed: _signIn,
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor:
+                                Theme.of(context).primaryColor,
+                            foregroundColor: Colors.white,
+                            minimumSize: const Size(double.infinity, 55),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(8.0),
+                            ),
+                          ),
+                          child: Text(
+                            appLocalizations.signInButton,
+                            style: const TextStyle(
+                                fontSize: 18, fontWeight: FontWeight.bold),
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        ElevatedButton(
+                          onPressed: _quickSignIn,
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor:
+                                Theme.of(context).colorScheme.secondary,
+                            foregroundColor: Colors.white,
+                            minimumSize: const Size(double.infinity, 55),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(8.0),
+                            ),
+                          ),
+                          child: Text(
+                            appLocalizations.quickSignInButton,
+                            style: const TextStyle(
+                                fontSize: 18, fontWeight: FontWeight.bold),
+                          ),
+                        ),
+                      ],
+                    ),
             ],
           ),
         ),


### PR DESCRIPTION
## Summary
- add `signInOrCreate` to automatically register if account doesn't exist
- localize `quickSignInButton`
- expose new localization getter
- implement quick sign-in button on login screen

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486d739dd0832abfb76a6da2e95e7a