### PR TITLE
Enable auto sign-up on login

### DIFF
--- a/lib/presentation/auth/login_screen.dart
+++ b/lib/presentation/auth/login_screen.dart
@@ -25,7 +25,7 @@ class _LoginScreenState extends State<LoginScreen> {
       _errorMessage = null;
     });
     try {
-      await _authService.signInWithEmailPassword(
+      await _authService.signInOrCreate(
         _emailController.text,
         _passwordController.text,
       );


### PR DESCRIPTION
## Summary
- when a user logs in from the manual login form, automatically create an account if it doesn't exist by calling `signInOrCreate`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684873d1734c832a80c4a33e50724adc