### PR TITLE
Handle invalid credential error on sign in

### DIFF
--- a/lib/core/services/auth_service.dart
+++ b/lib/core/services/auth_service.dart
@@ -42,14 +42,25 @@ class AuthService {
     try {
       return await signInWithEmailPassword(email, password);
     } on FirebaseAuthException catch (e) {
-      if (e.code == 'user-not-found') {
+      if (e.code == 'user-not-found' || e.code == 'invalid-credential') {
         final defaultName = email.split('@').first;
-        return await signUpWithEmailPassword(
-          email,
-          password,
-          defaultName,
-          UserRole.unknown,
-        );
+        try {
+          return await signUpWithEmailPassword(
+            email,
+            password,
+            defaultName,
+            UserRole.unknown,
+          );
+        } on FirebaseAuthException catch (e2) {
+          if (e2.code == 'email-already-in-use') {
+            throw FirebaseAuthException(
+              code: 'wrong-password',
+              message:
+                  'كلمة المرور غير صحيحة. تأكد من إدخال كلمة المرور الصحيحة لهذا البريد.',
+            );
+          }
+          rethrow;
+        }
       }
       rethrow;
     }
@@ -63,8 +74,18 @@ class AuthService {
     try {
       return await signInWithEmailPassword(email, password);
     } on FirebaseAuthException catch (e) {
-      if (e.code == 'user-not-found') {
-        return await signUpWithEmailPassword(email, password, name, role);
+      if (e.code == 'user-not-found' || e.code == 'invalid-credential') {
+        try {
+          return await signUpWithEmailPassword(email, password, name, role);
+        } on FirebaseAuthException catch (e2) {
+          if (e2.code == 'email-already-in-use') {
+            throw FirebaseAuthException(
+              code: 'wrong-password',
+              message: 'كلمة المرور غير صحيحة. تأكد من إدخال كلمة المرور الصحيحة لهذا البريد.',
+            );
+          }
+          rethrow;
+        }
       } else if (e.code == 'wrong-password') {
         throw FirebaseAuthException(
           code: 'wrong-password',


### PR DESCRIPTION
## Summary
- create new account if Firebase throws `invalid-credential`
- treat `email-already-in-use` as a wrong password when signing up

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848894c0e68832a9a6212d36236ddc1