### PR TITLE
Add manager dashboard module

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -238,4 +238,9 @@
   "salesOrders": "طلبات المبيعات",
   "salesOrder": "طلب مبيعات",
   "quantityUnit": "كمية"
+  "managementDashboard": "لوحة القيادة والتقارير",
+  "productionEfficiency": "كفاءة الإنتاج",
+  "machineElectricityUsage": "استهلاك الكهرباء للآلات",
+  "qualityReports": "تقارير الجودة",
+  "salesStatus": "حالة المبيعات",
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -237,5 +237,10 @@
   "salesRepresentative": "مندوب المبيعات",
   "salesOrders": "Sales Orders",
   "salesOrder": "Sales Order",
+  "managementDashboard": "Management Dashboard",
+  "productionEfficiency": "Production Efficiency",
+  "machineElectricityUsage": "Machine Electricity Usage",
+  "qualityReports": "Quality Reports",
+  "salesStatus": "Sales Status",
   "quantityUnit": "كمية"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -252,6 +252,11 @@ class AppLocalizations {
   String get salesOrders => _strings["salesOrders"] ?? "salesOrders";
   String get salesOrder => _strings["salesOrder"] ?? "salesOrder";
   String get quantityUnit => _strings["quantityUnit"] ?? "quantityUnit";
+  String get managementDashboard => _strings["managementDashboard"] ?? "managementDashboard";
+  String get productionEfficiency => _strings["productionEfficiency"] ?? "productionEfficiency";
+  String get machineElectricityUsage => _strings["machineElectricityUsage"] ?? "machineElectricityUsage";
+  String get qualityReports => _strings["qualityReports"] ?? "qualityReports";
+  String get salesStatus => _strings["salesStatus"] ?? "salesStatus";
 }
 
 class AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/presentation/dashboard/manager_dashboard_screen.dart
+++ b/lib/presentation/dashboard/manager_dashboard_screen.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:plastic_factory_management/l10n/app_localizations.dart';
+
+class ManagerDashboardScreen extends StatelessWidget {
+  const ManagerDashboardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final appLocalizations = AppLocalizations.of(context)!;
+    final bool isTablet = MediaQuery.of(context).size.width > 600;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(appLocalizations.managementDashboard),
+        centerTitle: true,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: GridView.count(
+          crossAxisCount: isTablet ? 2 : 1,
+          crossAxisSpacing: 16,
+          mainAxisSpacing: 16,
+          childAspectRatio: 2.5,
+          children: [
+            _buildCard(
+              context,
+              icon: Icons.assessment,
+              title: appLocalizations.productionEfficiency,
+              value: '85%',
+            ),
+            _buildCard(
+              context,
+              icon: Icons.electric_bolt,
+              title: appLocalizations.machineElectricityUsage,
+              value: '1200 kWh',
+            ),
+            _buildCard(
+              context,
+              icon: Icons.check_circle,
+              title: appLocalizations.qualityReports,
+              value: '3 pending',
+            ),
+            _buildCard(
+              context,
+              icon: Icons.local_shipping,
+              title: appLocalizations.salesStatus,
+              value: '12 orders',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCard(BuildContext context,
+      {required IconData icon, required String title, required String value}) {
+    return Card(
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            Icon(icon, size: 40, color: Colors.blueGrey),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    title,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                    textAlign: TextAlign.right,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    value,
+                    style: TextStyle(color: Colors.grey[700]),
+                    textAlign: TextAlign.right,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -346,6 +346,15 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
 
       modules.add(_buildModuleButton(
         context: context,
+        title: appLocalizations.managementDashboard,
+        subtitle: "مؤشرات الأداء",
+        icon: Icons.dashboard,
+        color: moduleColors['management']!,
+        onPressed: () => Navigator.of(context).pushNamed(AppRouter.managerDashboardRoute),
+      ));
+
+      modules.add(_buildModuleButton(
+        context: context,
         title: "إدارة المستخدمين",
         subtitle: "صلاحيات المستخدمين",
         icon: Icons.manage_accounts,

--- a/lib/presentation/routes/app_router.dart
+++ b/lib/presentation/routes/app_router.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:plastic_factory_management/presentation/auth/login_screen.dart';
 import 'package:plastic_factory_management/presentation/home/home_screen.dart';
+import 'package:plastic_factory_management/presentation/dashboard/manager_dashboard_screen.dart';
 import 'package:plastic_factory_management/presentation/production/create_production_order_screen.dart';
 import 'package:plastic_factory_management/presentation/production/production_orders_list_screen.dart';
 import 'package:plastic_factory_management/presentation/inventory/raw_materials_screen.dart';
@@ -24,6 +25,7 @@ class AppRouter {
   static const String machineProfilesRoute = '/machinery/machines';
   static const String operatorProfilesRoute = '/machinery/operators';
   static const String maintenanceProgramRoute = '/maintenance/program';
+  static const String managerDashboardRoute = '/management/dashboard';
   static const String customerManagementRoute = '/sales/customers'; // مسار جديد
   static const String createSalesOrderRoute = '/sales/orders/create'; // مسار جديد
   static const String salesOrdersListRoute = '/sales/orders/list'; // مسار جديد
@@ -48,6 +50,8 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => OperatorProfilesScreen());
       case maintenanceProgramRoute:
         return MaterialPageRoute(builder: (_) => MaintenanceProgramScreen());
+      case managerDashboardRoute:
+        return MaterialPageRoute(builder: (_) => ManagerDashboardScreen());
       case customerManagementRoute: // إضافة المسار الجديد
         return MaterialPageRoute(builder: (_) => CustomerManagementScreen());
       case createSalesOrderRoute: // إضافة المسار الجديد


### PR DESCRIPTION
## Summary
- add new management dashboard screen with placeholder metrics
- add localization strings for new dashboard
- hook up dashboard route and navigation

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684add81df60832a8587e43c3141a5f1