### PR TITLE
Fix dropdown equality issue

### DIFF
--- a/lib/data/models/machine_model.dart
+++ b/lib/data/models/machine_model.dart
@@ -101,4 +101,13 @@ class MachineModel {
       lastMaintenance: lastMaintenance ?? this.lastMaintenance,
     );
   }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is MachineModel && other.id == id;
+  }
+
+  @override
+  int get hashCode => id.hashCode;
 }


### PR DESCRIPTION
## Summary
- implement equality for `MachineModel`

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68528ef9e444832aa9fbcfc3c9c21dc1