### PR TITLE
Add user management module

### DIFF
--- a/lib/data/datasources/user_datasource.dart
+++ b/lib/data/datasources/user_datasource.dart
@@ -1,0 +1,43 @@
+// plastic_factory_management/lib/data/datasources/user_datasource.dart
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:plastic_factory_management/data/models/user_model.dart';
+
+class UserDatasource {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+
+  Stream<List<UserModel>> getUsers() {
+    return _firestore.collection('users').snapshots().map((snapshot) {
+      return snapshot.docs
+          .map((doc) => UserModel.fromDocumentSnapshot(doc))
+          .toList();
+    });
+  }
+
+  Future<UserModel?> getUserById(String uid) async {
+    final doc = await _firestore.collection('users').doc(uid).get();
+    if (doc.exists) {
+      return UserModel.fromDocumentSnapshot(doc);
+    }
+    return null;
+  }
+
+  Future<void> addUser(UserModel user, String password) async {
+    UserCredential cred = await _auth.createUserWithEmailAndPassword(
+      email: user.email,
+      password: password,
+    );
+    final newUser = user.copyWith(uid: cred.user!.uid, createdAt: Timestamp.now());
+    await _firestore.collection('users').doc(cred.user!.uid).set(newUser.toMap());
+  }
+
+  Future<void> updateUser(UserModel user) async {
+    await _firestore.collection('users').doc(user.uid).update(user.toMap());
+  }
+
+  Future<void> deleteUser(String uid) async {
+    await _firestore.collection('users').doc(uid).delete();
+  }
+}

--- a/lib/data/models/user_model.dart
+++ b/lib/data/models/user_model.dart
@@ -59,4 +59,25 @@ class UserModel {
 
   // دالة مساعدة للحصول على الدور كـ Enum
   UserRole get userRoleEnum => UserRoleExtension.fromString(role);
+
+  UserModel copyWith({
+    String? uid,
+    String? email,
+    String? name,
+    String? role,
+    String? employeeId,
+    Timestamp? createdAt,
+  }) {
+    return UserModel(
+      uid: uid ?? this.uid,
+      email: email ?? this.email,
+      name: name ?? this.name,
+      role: role ?? this.role,
+      employeeId: employeeId ?? this.employeeId,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  // دالة مساعدة للحصول على الدور كـ Enum
+  UserRole get userRoleEnum => UserRoleExtension.fromString(role);
 }

--- a/lib/data/repositories/user_repository_impl.dart
+++ b/lib/data/repositories/user_repository_impl.dart
@@ -1,0 +1,36 @@
+// plastic_factory_management/lib/data/repositories/user_repository_impl.dart
+
+import 'package:plastic_factory_management/data/datasources/user_datasource.dart';
+import 'package:plastic_factory_management/data/models/user_model.dart';
+import 'package:plastic_factory_management/domain/repositories/user_repository.dart';
+
+class UserRepositoryImpl implements UserRepository {
+  final UserDatasource datasource;
+
+  UserRepositoryImpl(this.datasource);
+
+  @override
+  Stream<List<UserModel>> getUsers() {
+    return datasource.getUsers();
+  }
+
+  @override
+  Future<UserModel?> getUserById(String uid) {
+    return datasource.getUserById(uid);
+  }
+
+  @override
+  Future<void> addUser(UserModel user, String password) {
+    return datasource.addUser(user, password);
+  }
+
+  @override
+  Future<void> updateUser(UserModel user) {
+    return datasource.updateUser(user);
+  }
+
+  @override
+  Future<void> deleteUser(String uid) {
+    return datasource.deleteUser(uid);
+  }
+}

--- a/lib/domain/repositories/user_repository.dart
+++ b/lib/domain/repositories/user_repository.dart
@@ -1,0 +1,10 @@
+// plastic_factory_management/lib/domain/repositories/user_repository.dart
+
+import "package:plastic_factory_management/data/models/user_model.dart";
+abstract class UserRepository {
+  Stream<List<UserModel>> getUsers();
+  Future<UserModel?> getUserById(String uid);
+  Future<void> addUser(UserModel user, String password);
+  Future<void> updateUser(UserModel user);
+  Future<void> deleteUser(String uid);
+}

--- a/lib/domain/usecases/user_usecases.dart
+++ b/lib/domain/usecases/user_usecases.dart
@@ -1,0 +1,60 @@
+// plastic_factory_management/lib/domain/usecases/user_usecases.dart
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:plastic_factory_management/data/models/user_model.dart';
+import 'package:plastic_factory_management/domain/repositories/user_repository.dart';
+import 'package:plastic_factory_management/core/constants/app_enums.dart';
+
+class UserUseCases {
+  final UserRepository repository;
+
+  UserUseCases(this.repository);
+
+  Stream<List<UserModel>> getUsers() {
+    return repository.getUsers();
+  }
+
+  Future<UserModel?> getUserById(String uid) {
+    return repository.getUserById(uid);
+  }
+
+  Future<void> addUser({
+    required String email,
+    required String name,
+    required UserRole role,
+    required String password,
+    String? employeeId,
+  }) {
+    final user = UserModel(
+      uid: '',
+      email: email,
+      name: name,
+      role: role.toFirestoreString(),
+      employeeId: employeeId,
+      createdAt: Timestamp.now(),
+    );
+    return repository.addUser(user, password);
+  }
+
+  Future<void> updateUser({
+    required String uid,
+    required String email,
+    required String name,
+    required UserRole role,
+    String? employeeId,
+  }) {
+    final user = UserModel(
+      uid: uid,
+      email: email,
+      name: name,
+      role: role.toFirestoreString(),
+      employeeId: employeeId,
+      createdAt: Timestamp.now(),
+    );
+    return repository.updateUser(user);
+  }
+
+  Future<void> deleteUser(String uid) {
+    return repository.deleteUser(uid);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,6 +37,10 @@ import 'package:plastic_factory_management/domain/usecases/maintenance_usecases.
 import 'package:plastic_factory_management/data/datasources/sales_datasource.dart'; // استيراد جديد
 import 'package:plastic_factory_management/data/repositories/sales_repository_impl.dart'; // استيراد جديد
 import 'package:plastic_factory_management/domain/usecases/sales_usecases.dart'; // استيراد جديد
+// استيرادات User Management
+import 'package:plastic_factory_management/data/datasources/user_datasource.dart';
+import 'package:plastic_factory_management/data/repositories/user_repository_impl.dart';
+import 'package:plastic_factory_management/domain/usecases/user_usecases.dart';
 
 
 import 'package:plastic_factory_management/presentation/auth/login_screen.dart';
@@ -138,6 +142,20 @@ class MyApp extends StatelessWidget {
         Provider<SalesUseCases>(
           create: (context) => SalesUseCases(
             Provider.of<SalesRepositoryImpl>(context, listen: false),
+          ),
+        ),
+        // توفير User Management Dependencies
+        Provider<UserDatasource>(
+          create: (_) => UserDatasource(),
+        ),
+        Provider<UserRepositoryImpl>(
+          create: (context) => UserRepositoryImpl(
+            Provider.of<UserDatasource>(context, listen: false),
+          ),
+        ),
+        Provider<UserUseCases>(
+          create: (context) => UserUseCases(
+            Provider.of<UserRepositoryImpl>(context, listen: false),
           ),
         ),
       ],

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -355,8 +355,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
         subtitle: "صلاحيات المستخدمين",
         icon: Icons.manage_accounts,
         color: moduleColors['management']!,
-        onPressed: () {},
-        isComingSoon: true,
+        onPressed: () => Navigator.of(context).pushNamed(AppRouter.userManagementRoute),
       ));
     }
 

--- a/lib/presentation/management/user_management_screen.dart
+++ b/lib/presentation/management/user_management_screen.dart
@@ -1,0 +1,230 @@
+// plastic_factory_management/lib/presentation/management/user_management_screen.dart
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:plastic_factory_management/l10n/app_localizations.dart';
+import 'package:plastic_factory_management/data/models/user_model.dart';
+import 'package:plastic_factory_management/domain/usecases/user_usecases.dart';
+import 'package:plastic_factory_management/core/constants/app_enums.dart';
+
+class UserManagementScreen extends StatefulWidget {
+  @override
+  _UserManagementScreenState createState() => _UserManagementScreenState();
+}
+
+class _UserManagementScreenState extends State<UserManagementScreen> {
+  @override
+  Widget build(BuildContext context) {
+    final appLocalizations = AppLocalizations.of(context)!;
+    final userUseCases = Provider.of<UserUseCases>(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('إدارة المستخدمين'),
+        centerTitle: true,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.person_add),
+            onPressed: () {
+              _showAddEditUserDialog(context, userUseCases, appLocalizations);
+            },
+            tooltip: 'إضافة مستخدم',
+          ),
+        ],
+      ),
+      body: StreamBuilder<List<UserModel>>(
+        stream: userUseCases.getUsers(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('خطأ في تحميل المستخدمين: ${snapshot.error}'));
+          }
+          if (!snapshot.hasData || snapshot.data!.isEmpty) {
+            return const Center(child: Text('لا يوجد مستخدمون.'));
+          }
+
+          return ListView.builder(
+            itemCount: snapshot.data!.length,
+            itemBuilder: (context, index) {
+              final user = snapshot.data![index];
+              return Card(
+                margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                child: ListTile(
+                  title: Text(
+                    user.name,
+                    textDirection: TextDirection.rtl,
+                    textAlign: TextAlign.right,
+                  ),
+                  subtitle: Text(
+                    UserRoleExtension.fromString(user.role).toArabicString(),
+                    textDirection: TextDirection.rtl,
+                    textAlign: TextAlign.right,
+                  ),
+                  trailing: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      IconButton(
+                        icon: const Icon(Icons.edit, color: Colors.blue),
+                        onPressed: () {
+                          _showAddEditUserDialog(context, userUseCases, appLocalizations, user: user);
+                        },
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.delete, color: Colors.red),
+                        onPressed: () {
+                          _showDeleteConfirmationDialog(context, userUseCases, appLocalizations, user.uid, user.name);
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  void _showAddEditUserDialog(BuildContext context, UserUseCases useCases, AppLocalizations appLocalizations, {UserModel? user}) {
+    final _formKey = GlobalKey<FormState>();
+    final TextEditingController emailController = TextEditingController(text: user?.email ?? '');
+    final TextEditingController nameController = TextEditingController(text: user?.name ?? '');
+    final TextEditingController employeeIdController = TextEditingController(text: user?.employeeId ?? '');
+    final TextEditingController passwordController = TextEditingController();
+    UserRole role = user != null ? UserRoleExtension.fromString(user.role) : UserRole.productionShiftSupervisor;
+
+    showDialog(
+      context: context,
+      builder: (context) {
+        final isEditing = user != null;
+        return AlertDialog(
+          title: Text(isEditing ? 'تعديل مستخدم' : 'إضافة مستخدم'),
+          content: SingleChildScrollView(
+            child: Form(
+              key: _formKey,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  TextFormField(
+                    controller: emailController,
+                    decoration: const InputDecoration(labelText: 'البريد الإلكتروني'),
+                    validator: (value) => value!.isEmpty ? 'هذا الحقل مطلوب' : null,
+                    textAlign: TextAlign.right,
+                    textDirection: TextDirection.rtl,
+                  ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: nameController,
+                    decoration: const InputDecoration(labelText: 'الاسم'),
+                    validator: (value) => value!.isEmpty ? 'هذا الحقل مطلوب' : null,
+                    textAlign: TextAlign.right,
+                    textDirection: TextDirection.rtl,
+                  ),
+                  const SizedBox(height: 12),
+                  DropdownButtonFormField<UserRole>(
+                    value: role,
+                    decoration: const InputDecoration(labelText: 'الدور'),
+                    items: UserRole.values
+                        .where((r) => r != UserRole.unknown)
+                        .map((r) => DropdownMenuItem(
+                              value: r,
+                              child: Text(r.toArabicString(), textDirection: TextDirection.rtl),
+                            ))
+                        .toList(),
+                    onChanged: (r) => role = r!,
+                  ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: employeeIdController,
+                    decoration: const InputDecoration(labelText: 'رقم الموظف'),
+                    textAlign: TextAlign.right,
+                    textDirection: TextDirection.rtl,
+                  ),
+                  if (!isEditing) ...[
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      controller: passwordController,
+                      decoration: const InputDecoration(labelText: 'كلمة المرور'),
+                      obscureText: true,
+                      validator: (value) => value!.isEmpty ? 'هذا الحقل مطلوب' : null,
+                      textAlign: TextAlign.right,
+                      textDirection: TextDirection.rtl,
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+          actions: [
+            TextButton(
+              child: const Text('إلغاء'),
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+            ElevatedButton(
+              child: Text(isEditing ? 'حفظ' : 'إضافة'),
+              onPressed: () async {
+                if (_formKey.currentState!.validate()) {
+                  try {
+                    if (isEditing) {
+                      await useCases.updateUser(
+                        uid: user!.uid,
+                        email: emailController.text,
+                        name: nameController.text,
+                        role: role,
+                        employeeId: employeeIdController.text.isEmpty ? null : employeeIdController.text,
+                      );
+                    } else {
+                      await useCases.addUser(
+                        email: emailController.text,
+                        name: nameController.text,
+                        role: role,
+                        password: passwordController.text,
+                        employeeId: employeeIdController.text.isEmpty ? null : employeeIdController.text,
+                      );
+                    }
+                    Navigator.of(context).pop();
+                  } catch (e) {
+                    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('خطأ: $e')));
+                  }
+                }
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _showDeleteConfirmationDialog(BuildContext context, UserUseCases useCases, AppLocalizations appLocalizations, String uid, String name) {
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('تأكيد الحذف'),
+          content: Text('هل أنت متأكد من حذف المستخدم "$name"؟'),
+          actions: [
+            TextButton(
+              child: const Text('إلغاء'),
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+            ElevatedButton(
+              child: const Text('حذف'),
+              onPressed: () async {
+                try {
+                  await useCases.deleteUser(uid);
+                  Navigator.of(context).pop();
+                } catch (e) {
+                  ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('خطأ: $e')));
+                }
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/presentation/routes/app_router.dart
+++ b/lib/presentation/routes/app_router.dart
@@ -17,6 +17,7 @@ import 'package:plastic_factory_management/presentation/quality/quality_inspecti
 import 'package:plastic_factory_management/presentation/inventory/inventory_management_screen.dart';
 import 'package:plastic_factory_management/presentation/accounting/accounting_screen.dart';
 import 'package:plastic_factory_management/presentation/notifications/notifications_screen.dart';
+import 'package:plastic_factory_management/presentation/management/user_management_screen.dart';
 
 
 class AppRouter {
@@ -35,6 +36,7 @@ class AppRouter {
   static const String qualityInspectionRoute = '/quality/inspections';
   static const String inventoryManagementRoute = '/inventory/management';
   static const String accountingRoute = '/accounting';
+  static const String userManagementRoute = '/management/users';
   static const String notificationsRoute = '/notifications';
 
   static Route<dynamic> generateRoute(RouteSettings settings) {
@@ -69,6 +71,8 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => InventoryManagementScreen());
       case accountingRoute:
         return MaterialPageRoute(builder: (_) => AccountingScreen());
+      case userManagementRoute:
+        return MaterialPageRoute(builder: (_) => UserManagementScreen());
       case notificationsRoute:
         return MaterialPageRoute(builder: (_) => const NotificationsScreen());
       default:


### PR DESCRIPTION
## Summary
- add interfaces and implementations for user management
- expose user management dependencies in `main.dart`
- add user management screens and routes
- enable navigation from the home screen
- extend `UserModel` with `copyWith`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68529bfb8638832abc315365c4c43de8