### PR TITLE
Add warehouse requests module

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -259,6 +259,8 @@
   "uploadImages": "تحميل الصور",
   "documentationSaved": "تم حفظ التوثيق بنجاح",
   "errorSavingDocumentation": "حدث خطأ أثناء حفظ التوثيق",
+  "warehouseRequests": "طلبات المخزن",
+  "prepareOrder": "تجهيز الطلب",
   "performanceSummary": "ملخص الأداء",
   "productionRequests": "طلبات الإنتاج",
   "criticalRawMaterials": "مواد خام حرجة",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -265,6 +265,8 @@
   "uploadImages": "Upload images",
   "documentationSaved": "Documentation saved successfully",
   "errorSavingDocumentation": "Error saving documentation",
+  "warehouseRequests": "Warehouse Requests",
+  "prepareOrder": "Prepare Order",
   "performanceSummary": "ملخص الأداء",
   "productionRequests": "طلبات الإنتاج",
   "criticalRawMaterials": "مواد خام حرجة",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -273,6 +273,8 @@ class AppLocalizations {
   String get uploadImages => _strings["uploadImages"] ?? "uploadImages";
   String get documentationSaved => _strings["documentationSaved"] ?? "documentationSaved";
   String get errorSavingDocumentation => _strings["errorSavingDocumentation"] ?? "errorSavingDocumentation";
+  String get warehouseRequests => _strings["warehouseRequests"] ?? "warehouseRequests";
+  String get prepareOrder => _strings["prepareOrder"] ?? "prepareOrder";
   String get notifications => _strings["notifications"] ?? "notifications";
   String get noNotifications => _strings["noNotifications"] ?? "noNotifications";
 }

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -490,6 +490,15 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
         color: moduleColors['inventory']!,
         onPressed: () => Navigator.of(context).pushNamed(AppRouter.productCatalogRoute),
       ));
+
+      modules.add(_buildModuleButton(
+        context: context,
+        title: appLocalizations.warehouseRequests,
+        subtitle: "طلبات المخزن",
+        icon: Icons.local_shipping,
+        color: moduleColors['inventory']!,
+        onPressed: () => Navigator.of(context).pushNamed(AppRouter.warehouseRequestsRoute),
+      ));
     }
 
     // Modules for Machine Operator (مشغل المكينة)

--- a/lib/presentation/inventory/warehouse_requests_screen.dart
+++ b/lib/presentation/inventory/warehouse_requests_screen.dart
@@ -1,0 +1,195 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:provider/provider.dart';
+import 'package:plastic_factory_management/l10n/app_localizations.dart';
+import 'package:plastic_factory_management/data/models/sales_order_model.dart';
+import 'package:plastic_factory_management/domain/usecases/sales_usecases.dart';
+
+class WarehouseRequestsScreen extends StatefulWidget {
+  const WarehouseRequestsScreen({Key? key}) : super(key: key);
+
+  @override
+  _WarehouseRequestsScreenState createState() => _WarehouseRequestsScreenState();
+}
+
+class _WarehouseRequestsScreenState extends State<WarehouseRequestsScreen> {
+  void _showWarehouseDocDialog(BuildContext context, SalesUseCases useCases,
+      AppLocalizations appLocalizations, SalesOrderModel order) {
+    final TextEditingController notesController =
+        TextEditingController(text: order.warehouseNotes);
+    List<XFile> pickedImages = [];
+    final ImagePicker picker = ImagePicker();
+
+    Future<void> pickImages() async {
+      final images = await picker.pickMultiImage();
+      if (images != null) {
+        pickedImages.addAll(images);
+      }
+    }
+
+    Future<void> captureImage() async {
+      final image = await picker.pickImage(source: ImageSource.camera);
+      if (image != null) {
+        pickedImages.add(image);
+      }
+    }
+
+    showDialog(
+      context: context,
+      builder: (context) => StatefulBuilder(
+        builder: (context, setState) => AlertDialog(
+          title: Text(appLocalizations.warehouseDocumentation),
+          content: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextField(
+                  controller: notesController,
+                  decoration: InputDecoration(labelText: appLocalizations.enterNotes),
+                  maxLines: 3,
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  children: [
+                    ElevatedButton.icon(
+                      onPressed: () async {
+                        await captureImage();
+                        setState(() {});
+                      },
+                      icon: const Icon(Icons.camera_alt),
+                      label: Text(appLocalizations.camera),
+                    ),
+                    ElevatedButton.icon(
+                      onPressed: () async {
+                        await pickImages();
+                        setState(() {});
+                      },
+                      icon: const Icon(Icons.photo),
+                      label: Text(appLocalizations.gallery),
+                    ),
+                  ],
+                ),
+                Wrap(
+                  children: pickedImages
+                      .map((e) => Padding(
+                            padding: const EdgeInsets.all(4.0),
+                            child: Image.file(
+                              File(e.path),
+                              width: 60,
+                              height: 60,
+                              fit: BoxFit.cover,
+                            ),
+                          ))
+                      .toList(),
+                )
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              child: Text(appLocalizations.cancel),
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+            ElevatedButton(
+              child: Text(appLocalizations.sendToProduction),
+              onPressed: () async {
+                Navigator.of(context).pop();
+                try {
+                  await useCases.documentWarehouseSupply(
+                    order: order,
+                    notes: notesController.text.trim(),
+                    attachments: pickedImages.map((e) => File(e.path)).toList(),
+                  );
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text(appLocalizations.supplySaved)),
+                  );
+                } catch (e) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('${appLocalizations.errorSavingSupply}: $e')),
+                  );
+                }
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final salesUseCases = Provider.of<SalesUseCases>(context);
+    final appLocalizations = AppLocalizations.of(context)!;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(appLocalizations.warehouseRequests),
+        centerTitle: true,
+      ),
+      body: StreamBuilder<List<SalesOrderModel>>(
+        stream: salesUseCases.getSalesOrders(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('خطأ في تحميل الطلبات: ${snapshot.error}'));
+          }
+          if (!snapshot.hasData || snapshot.data!.isEmpty) {
+            return Center(child: Text('لا توجد طلبات حالياً.'));
+          }
+
+          final orders = snapshot.data!
+              .where((o) => o.status == SalesOrderStatus.warehouseProcessing)
+              .toList();
+
+          if (orders.isEmpty) {
+            return Center(child: Text('لا توجد طلبات حالياً.'));
+          }
+
+          return ListView.builder(
+            itemCount: orders.length,
+            itemBuilder: (context, index) {
+              final order = orders[index];
+              return Card(
+                margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                elevation: 3,
+                child: ListTile(
+                  title: Text(
+                    'طلب العميل: ${order.customerName}',
+                    textDirection: TextDirection.rtl,
+                    textAlign: TextAlign.right,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  subtitle: Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        "${appLocalizations.totalAmount}: \$${order.totalAmount.toStringAsFixed(2)}",
+                        textDirection: TextDirection.rtl,
+                        textAlign: TextAlign.right,
+                      ),
+                      Text(
+                        "${appLocalizations.salesRepresentative}: ${order.salesRepresentativeName}",
+                        textDirection: TextDirection.rtl,
+                        textAlign: TextAlign.right,
+                      ),
+                    ],
+                  ),
+                  trailing: ElevatedButton(
+                    child: Text(appLocalizations.prepareOrder),
+                    onPressed: () => _showWarehouseDocDialog(
+                        context, salesUseCases, appLocalizations, order),
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/presentation/routes/app_router.dart
+++ b/lib/presentation/routes/app_router.dart
@@ -15,6 +15,7 @@ import 'package:plastic_factory_management/presentation/sales/create_sales_order
 import 'package:plastic_factory_management/presentation/sales/sales_orders_list_screen.dart'; // استيراد جديد
 import 'package:plastic_factory_management/presentation/quality/quality_inspection_screen.dart';
 import 'package:plastic_factory_management/presentation/inventory/inventory_management_screen.dart';
+import 'package:plastic_factory_management/presentation/inventory/warehouse_requests_screen.dart';
 import 'package:plastic_factory_management/presentation/accounting/accounting_screen.dart';
 import 'package:plastic_factory_management/presentation/notifications/notifications_screen.dart';
 import 'package:plastic_factory_management/presentation/management/user_management_screen.dart';
@@ -35,6 +36,7 @@ class AppRouter {
   static const String salesOrdersListRoute = '/sales/orders/list'; // مسار جديد
   static const String qualityInspectionRoute = '/quality/inspections';
   static const String inventoryManagementRoute = '/inventory/management';
+  static const String warehouseRequestsRoute = '/inventory/warehouse_requests';
   static const String accountingRoute = '/accounting';
   static const String userManagementRoute = '/management/users';
   static const String notificationsRoute = '/notifications';
@@ -69,6 +71,8 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => QualityInspectionScreen());
       case inventoryManagementRoute:
         return MaterialPageRoute(builder: (_) => InventoryManagementScreen());
+      case warehouseRequestsRoute:
+        return MaterialPageRoute(builder: (_) => WarehouseRequestsScreen());
       case accountingRoute:
         return MaterialPageRoute(builder: (_) => AccountingScreen());
       case userManagementRoute:

--- a/lib/presentation/sales/sales_orders_list_screen.dart
+++ b/lib/presentation/sales/sales_orders_list_screen.dart
@@ -515,6 +515,13 @@ class _SalesOrdersListScreenState extends State<SalesOrdersListScreen> {
       }
     }
 
+    Future<void> captureImage() async {
+      final image = await picker.pickImage(source: ImageSource.camera);
+      if (image != null) {
+        pickedImages.add(image);
+      }
+    }
+
     showDialog(
       context: context,
       builder: (context) => StatefulBuilder(
@@ -530,13 +537,26 @@ class _SalesOrdersListScreenState extends State<SalesOrdersListScreen> {
                   maxLines: 3,
                 ),
                 const SizedBox(height: 8),
-                ElevatedButton.icon(
-                  onPressed: () async {
-                    await pickImages();
-                    setState(() {});
-                  },
-                  icon: const Icon(Icons.photo),
-                  label: Text(appLocalizations.uploadImages),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  children: [
+                    ElevatedButton.icon(
+                      onPressed: () async {
+                        await captureImage();
+                        setState(() {});
+                      },
+                      icon: const Icon(Icons.camera_alt),
+                      label: Text(appLocalizations.camera),
+                    ),
+                    ElevatedButton.icon(
+                      onPressed: () async {
+                        await pickImages();
+                        setState(() {});
+                      },
+                      icon: const Icon(Icons.photo),
+                      label: Text(appLocalizations.gallery),
+                    ),
+                  ],
                 ),
                 Wrap(
                   children: pickedImages.map((e) => Padding(
@@ -605,13 +625,26 @@ class _SalesOrdersListScreenState extends State<SalesOrdersListScreen> {
                   maxLines: 3,
                 ),
                 const SizedBox(height: 8),
-                ElevatedButton.icon(
-                  onPressed: () async {
-                    await pickImages();
-                    setState(() {});
-                  },
-                  icon: const Icon(Icons.photo),
-                  label: Text(appLocalizations.uploadImages),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  children: [
+                    ElevatedButton.icon(
+                      onPressed: () async {
+                        await captureImage();
+                        setState(() {});
+                      },
+                      icon: const Icon(Icons.camera_alt),
+                      label: Text(appLocalizations.camera),
+                    ),
+                    ElevatedButton.icon(
+                      onPressed: () async {
+                        await pickImages();
+                        setState(() {});
+                      },
+                      icon: const Icon(Icons.photo),
+                      label: Text(appLocalizations.gallery),
+                    ),
+                  ],
                 ),
                 Wrap(
                   children: pickedImages.map((e) => Padding(


### PR DESCRIPTION
## Summary
- add WarehouseRequestsScreen for inventory manager
- add route and menu entry for warehouse requests
- allow taking photos in warehouse documentation
- localize new strings

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6852f60981d4832ab05adf51455e7606