### PR TITLE
Add warehouse requests button to inventory dashboard

### DIFF
--- a/lib/presentation/inventory/inventory_management_screen.dart
+++ b/lib/presentation/inventory/inventory_management_screen.dart
@@ -33,6 +33,13 @@ class InventoryManagementScreen extends StatelessWidget {
             ),
             const SizedBox(height: 16),
             ElevatedButton.icon(
+              icon: const Icon(Icons.local_shipping),
+              label: Text(appLocalizations.warehouseRequests),
+              onPressed: () =>
+                  Navigator.of(context).pushNamed(AppRouter.warehouseRequestsRoute),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton.icon(
               icon: const Icon(Icons.inventory_2_outlined),
               label: const Text('استلام المنتجات الجاهزة', textDirection: TextDirection.rtl),
               onPressed: () {},


### PR DESCRIPTION
## Summary
- expose warehouse requests from the inventory management screen so storekeepers can access them easily

## Testing
- `flutter test -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852fe626eac832aa35b491b929cf997