### PR TITLE
Add mold installation supervisor tasks section

### DIFF
--- a/lib/domain/usecases/production_order_usecases.dart
+++ b/lib/domain/usecases/production_order_usecases.dart
@@ -52,6 +52,15 @@ class ProductionOrderUseCases {
     });
   }
 
+  // Orders awaiting mold installation supervisor receipt
+  Stream<List<ProductionOrderModel>> getOrdersAwaitingMoldInstallation() {
+    return repository.getProductionOrders().map((orders) {
+      return orders.where((order) =>
+          order.currentStage == 'استلام مشرف تركيب القوالب' &&
+          order.status == ProductionOrderStatus.approved).toList();
+    });
+  }
+
   Future<ProductionOrderModel?> getProductionOrderById(String orderId) {
     return repository.getProductionOrderById(orderId);
   }

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -301,4 +301,6 @@
   ,"orderFlowDetails": "تفاصيل الإعتمادات"
   ,"approvedBy": "اعتمد بواسطة"
   ,"approvalTime": "وقت الاعتماد"
+  ,"moldInstallationTasks": "مهام تركيب القوالب"
+  ,"noMoldInstallationOrders": "لا توجد طلبات بانتظار تركيب القوالب"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -307,4 +307,6 @@
   ,"orderFlowDetails": "Approval Details"
   ,"approvedBy": "Approved By"
   ,"approvalTime": "Approval Time"
+  ,"moldInstallationTasks": "Mold Installation Tasks"
+  ,"noMoldInstallationOrders": "No orders awaiting mold installation"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -284,6 +284,8 @@ class AppLocalizations {
   String get orderFlowDetails => _strings["orderFlowDetails"] ?? "orderFlowDetails";
   String get approvedBy => _strings["approvedBy"] ?? "approvedBy";
   String get approvalTime => _strings["approvalTime"] ?? "approvalTime";
+  String get moldInstallationTasks => _strings["moldInstallationTasks"] ?? "moldInstallationTasks";
+  String get noMoldInstallationOrders => _strings["noMoldInstallationOrders"] ?? "noMoldInstallationOrders";
 }
 
 class AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -451,12 +451,11 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
     if (role == UserRole.moldInstallationSupervisor) {
       modules.add(_buildModuleButton(
         context: context,
-        title: "مهام تركيب القوالب",
+        title: appLocalizations.moldInstallationTasks,
         subtitle: "تركيب وصيانة القوالب",
         icon: Icons.extension,
         color: moduleColors['machinery']!,
-        onPressed: () {},
-        isComingSoon: true,
+        onPressed: () => Navigator.of(context).pushNamed(AppRouter.moldInstallationTasksRoute),
       ));
     }
 

--- a/lib/presentation/machinery/mold_installation_tasks_screen.dart
+++ b/lib/presentation/machinery/mold_installation_tasks_screen.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:plastic_factory_management/l10n/app_localizations.dart';
+import 'package:plastic_factory_management/data/models/production_order_model.dart';
+import 'package:plastic_factory_management/data/models/user_model.dart';
+import 'package:plastic_factory_management/domain/usecases/production_order_usecases.dart';
+import 'package:plastic_factory_management/presentation/production/production_order_detail_screen.dart';
+
+class MoldInstallationTasksScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final appLocalizations = AppLocalizations.of(context)!;
+    final productionUseCases = Provider.of<ProductionOrderUseCases>(context);
+    final currentUser = Provider.of<UserModel?>(context);
+
+    if (currentUser == null) {
+      return Scaffold(
+        appBar: AppBar(title: Text(appLocalizations.moldInstallationTasks)),
+        body: Center(child: Text(appLocalizations.errorLoadingUserData)),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(appLocalizations.moldInstallationTasks),
+        centerTitle: true,
+      ),
+      body: StreamBuilder<List<ProductionOrderModel>>(
+        stream: productionUseCases.getOrdersAwaitingMoldInstallation(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('خطأ: ${snapshot.error}'));
+          }
+          if (!snapshot.hasData || snapshot.data!.isEmpty) {
+            return Center(child: Text(appLocalizations.noMoldInstallationOrders));
+          }
+
+          final orders = snapshot.data!;
+          return ListView.builder(
+            itemCount: orders.length,
+            itemBuilder: (context, index) {
+              final order = orders[index];
+              return Card(
+                margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                elevation: 3,
+                child: ListTile(
+                  onTap: () {
+                    Navigator.of(context).push(MaterialPageRoute(
+                      builder: (_) => ProductionOrderDetailScreen(order: order),
+                    ));
+                  },
+                  title: Text(
+                    '${appLocalizations.product}: ${order.productName}',
+                    textDirection: TextDirection.rtl,
+                    textAlign: TextAlign.right,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  subtitle: Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        '${appLocalizations.requiredQuantity}: ${order.requiredQuantity}',
+                        textDirection: TextDirection.rtl,
+                        textAlign: TextAlign.right,
+                      ),
+                      Text(
+                        '${appLocalizations.batchNumber}: ${order.batchNumber}',
+                        textDirection: TextDirection.rtl,
+                        textAlign: TextAlign.right,
+                      ),
+                      Text(
+                        '${appLocalizations.orderPreparer}: ${order.orderPreparerName}',
+                        textDirection: TextDirection.rtl,
+                        textAlign: TextAlign.right,
+                      ),
+                    ],
+                  ),
+                  trailing: const Icon(Icons.arrow_forward_ios),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/presentation/routes/app_router.dart
+++ b/lib/presentation/routes/app_router.dart
@@ -9,6 +9,7 @@ import 'package:plastic_factory_management/presentation/inventory/raw_materials_
 import 'package:plastic_factory_management/presentation/inventory/product_catalog_screen.dart'; // يمكن إعادة استخدامها
 import 'package:plastic_factory_management/presentation/machinery/machine_profiles_screen.dart';
 import 'package:plastic_factory_management/presentation/machinery/operator_profiles_screen.dart';
+import 'package:plastic_factory_management/presentation/machinery/mold_installation_tasks_screen.dart';
 import 'package:plastic_factory_management/presentation/maintenance/maintenance_program_screen.dart';
 import 'package:plastic_factory_management/presentation/sales/customer_management_screen.dart'; // استيراد جديد
 import 'package:plastic_factory_management/presentation/sales/create_sales_order_screen.dart'; // استيراد جديد
@@ -30,6 +31,7 @@ class AppRouter {
   static const String productCatalogRoute = '/inventory/product_catalog';
   static const String machineProfilesRoute = '/machinery/machines';
   static const String operatorProfilesRoute = '/machinery/operators';
+  static const String moldInstallationTasksRoute = '/machinery/mold_tasks';
   static const String maintenanceProgramRoute = '/maintenance/program';
   static const String customerManagementRoute = '/sales/customers'; // مسار جديد
   static const String createSalesOrderRoute = '/sales/orders/create'; // مسار جديد
@@ -59,6 +61,8 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => MachineProfilesScreen());
       case operatorProfilesRoute:
         return MaterialPageRoute(builder: (_) => OperatorProfilesScreen());
+      case moldInstallationTasksRoute:
+        return MaterialPageRoute(builder: (_) => MoldInstallationTasksScreen());
       case maintenanceProgramRoute:
         return MaterialPageRoute(builder: (_) => MaintenanceProgramScreen());
       case customerManagementRoute: // إضافة المسار الجديد


### PR DESCRIPTION
## Summary
- add localization for mold installation supervisor tasks
- create `MoldInstallationTasksScreen` for supervisors
- expose `getOrdersAwaitingMoldInstallation` use case
- route to the new screen from home and router

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e8bf1fa4832a88e97fd0704f0995