### PR TITLE
Update app color scheme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,8 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:provider/provider.dart';
 import 'package:google_fonts/google_fonts.dart';
 
+import 'package:plastic_factory_management/theme/app_colors.dart';
+
 import 'package:plastic_factory_management/firebase_options.dart';
 import 'package:plastic_factory_management/l10n/app_localizations.dart';
 
@@ -195,23 +197,23 @@ class MyApp extends StatelessWidget {
           Locale('en', ''),
         ],
         theme: ThemeData(
-          primarySwatch: Colors.blueGrey,
-          appBarTheme: AppBarTheme(
-            backgroundColor: Colors.blueGrey[800],
+          primarySwatch: AppColors.primarySwatch,
+          appBarTheme: const AppBarTheme(
+            backgroundColor: AppColors.dark,
             foregroundColor: Colors.white,
             elevation: 0,
           ),
-          inputDecorationTheme: InputDecorationTheme(
+          inputDecorationTheme: const InputDecorationTheme(
             border: OutlineInputBorder(),
-            labelStyle: TextStyle(color: Colors.blueGrey[700]),
-            floatingLabelStyle: TextStyle(color: Colors.blueGrey[900]),
+            labelStyle: TextStyle(color: AppColors.dark),
+            floatingLabelStyle: TextStyle(color: AppColors.dark),
           ),
           elevatedButtonTheme: ElevatedButtonThemeData(
             style: ElevatedButton.styleFrom(
-              backgroundColor: Colors.blueGrey,
+              backgroundColor: AppColors.primary,
               foregroundColor: Colors.white,
-              padding: EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-              textStyle: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+              textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
               shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
             ),
           ),

--- a/lib/presentation/sales/sales_orders_list_screen.dart
+++ b/lib/presentation/sales/sales_orders_list_screen.dart
@@ -14,6 +14,7 @@ import 'package:image_picker/image_picker.dart';
 import 'dart:io';
 
 import 'create_sales_order_screen.dart';
+import '../../theme/app_colors.dart';
 
 class SalesOrdersListScreen extends StatefulWidget {
   @override
@@ -277,7 +278,7 @@ class _SalesOrdersListScreenState extends State<SalesOrdersListScreen> {
         );
       } else {
         return IconButton(
-          icon: const Icon(Icons.camera_alt, color: Colors.blueGrey),
+          icon: const Icon(Icons.camera_alt, color: AppColors.dark),
           onPressed: () => _showMoldDocDialog(context, useCases, appLocalizations, order),
           tooltip: appLocalizations.moldInstallationDocumentation,
         );
@@ -289,7 +290,7 @@ class _SalesOrdersListScreenState extends State<SalesOrdersListScreen> {
   Color _getSalesOrderStatusColor(SalesOrderStatus status) {
     switch (status) {
       case SalesOrderStatus.pendingApproval:
-        return Colors.blueGrey;
+        return AppColors.dark;
       case SalesOrderStatus.pendingFulfillment:
         return Colors.orange;
       case SalesOrderStatus.warehouseProcessing:

--- a/lib/theme/app_colors.dart
+++ b/lib/theme/app_colors.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class AppColors {
+  static const Color primary = Color(0xFFE68A75);
+  static const Color dark = Color(0xFF423839);
+
+  static MaterialColor get primarySwatch => _createMaterialColor(primary);
+
+  static MaterialColor _createMaterialColor(Color color) {
+    final strengths = <double>[.05];
+    final swatch = <int, Color>{};
+    final r = color.red, g = color.green, b = color.blue;
+
+    for (int i = 1; i < 10; i++) {
+      strengths.add(0.1 * i);
+    }
+    for (var strength in strengths) {
+      final ds = 0.5 - strength;
+      swatch[(strength * 1000).round()] = Color.fromRGBO(
+        r + ((ds < 0 ? r : (255 - r)) * ds).round(),
+        g + ((ds < 0 ? g : (255 - g)) * ds).round(),
+        b + ((ds < 0 ? b : (255 - b)) * ds).round(),
+        1,
+      );
+    }
+    return MaterialColor(color.value, swatch);
+  }
+}


### PR DESCRIPTION
## Summary
- implement color constants and `AppColors`
- apply new color theme throughout the app
- replace old blue-grey references in sales screens

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f6895560832a873faf6f7de089b5