### PR TITLE
Fix sales orders screen issues

### DIFF
--- a/lib/presentation/sales/sales_orders_list_screen.dart
+++ b/lib/presentation/sales/sales_orders_list_screen.dart
@@ -915,7 +915,6 @@ class _SalesOrdersListScreenState extends State<SalesOrdersListScreen> {
               maxLines: 3,
               textAlign: TextAlign.right,
               textDirection: TextDirection.rtl,
-              validator: (value) => value!.trim().isEmpty ? appLocalizations.fieldRequired : null, // Added validation
             ),
           ],
         ),

--- a/lib/theme/app_colors.dart
+++ b/lib/theme/app_colors.dart
@@ -9,6 +9,12 @@ class AppColors {
   /// Secondary brand color used for gradients and dark elements.
   static const Color dark = Color(0xFF848484);
 
+  /// Secondary color used for highlights and accents.
+  static const Color secondary = Color(0xFF2196F3);
+
+  /// Accent orange color used for pending statuses.
+  static const Color accentOrange = Color(0xFFFFA726);
+
   /// Convenient list of gradient colors following the brand scheme.
   static const List<Color> gradient = [primary, dark];
 


### PR DESCRIPTION
## Summary
- add secondary and accentOrange colors to theme
- fix reject dialog TextField

## Testing
- `dart format lib/theme/app_colors.dart lib/presentation/sales/sales_orders_list_screen.dart` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68542f803efc832a8093a1b4557fec3e