### PR TITLE
Ensure RTL orientation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -196,6 +196,12 @@ class MyApp extends StatelessWidget {
           Locale('ar', ''),
           Locale('en', ''),
         ],
+        builder: (context, child) {
+          return Directionality(
+            textDirection: TextDirection.rtl,
+            child: child!,
+          );
+        },
         theme: ThemeData(
           primarySwatch: AppColors.primarySwatch,
           primaryColor: AppColors.primary,

--- a/web/index.html
+++ b/web/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html dir="rtl">
 <head>
   <!--
     If you are serving your web app in a path other than the root, change the


### PR DESCRIPTION
## Summary
- ensure RTL orientation by wrapping the MaterialApp with a Directionality widget
- add `dir="rtl"` attribute to the web entrypoint

## Testing
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_685446a5246c832ab45772c963b3dd5a