### PR TITLE
Fix missing localization references

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -389,6 +389,10 @@
               "errorSavingUser": "خطأ في حفظ المستخدم",
               "confirmDeleteUser": "تأكيد حذف المستخدم",
               "userDeletedSuccessfully": "تم حذف المستخدم بنجاح.",
-              "errorDeletingUser": "خطأ في حذف المستخدم"
-
+              "errorDeletingUser": "خطأ في حذف المستخدم",
+  "loginPrompt": "يرجى تسجيل الدخول للمتابعة.",
+  "login": "تسجيل الدخول",
+  "tryAgain": "حاول مرة أخرى",
+  "clearFilter": "مسح الفلتر",
+  "orderId": "رقم الطلب"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -396,5 +396,10 @@
   "confirmDeleteUser": "Confirm deleting user",
   "userDeletedSuccessfully": "User deleted successfully",
   "errorDeletingUser": "Error deleting user",
+  "loginPrompt": "Please log in to continue.",
+  "login": "Login",
+  "tryAgain": "Try Again",
+  "clearFilter": "Clear Filter",
+  "orderId": "Order ID",
   "unknown": "Unknown"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -382,6 +382,11 @@ class AppLocalizations {
   String get confirmDeleteUser => _strings["confirmDeleteUser"] ?? "confirmDeleteUser";
   String get userDeletedSuccessfully => _strings["userDeletedSuccessfully"] ?? "userDeletedSuccessfully";
   String get errorDeletingUser => _strings["errorDeletingUser"] ?? "errorDeletingUser";
+  String get loginPrompt => _strings["loginPrompt"] ?? "loginPrompt";
+  String get login => _strings["login"] ?? "login";
+  String get tryAgain => _strings["tryAgain"] ?? "tryAgain";
+  String get clearFilter => _strings["clearFilter"] ?? "clearFilter";
+  String get orderId => _strings["orderId"] ?? "orderId";
   String get unknown => _strings["unknown"] ?? "unknown";
 
 }


### PR DESCRIPTION
## Summary
- add new localization strings for login prompts
- expose the new keys in the localization class

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68568d25a17c832abe3389e61c76678f