### PR TITLE
Add approvedByName field to sales orders

### DIFF
--- a/lib/data/models/sales_order_model.dart
+++ b/lib/data/models/sales_order_model.dart
@@ -100,6 +100,7 @@ class SalesOrderModel {
   final Timestamp createdAt; // تاريخ إنشاء الطلب
   final String? customerSignatureUrl; // رابط صورة توقيع العميل
   final String? approvedByUid; // UID المحاسب الذي اعتمد الطلب
+  final String? approvedByName; // اسم المحاسب الذي اعتمد الطلب
   final Timestamp? approvedAt; // وقت الاعتماد
   final String? rejectionReason; // سبب الرفض إن وجد
   final bool moldTasksEnabled; // هل تم تفعيل مهام تركيب القوالب
@@ -129,6 +130,7 @@ class SalesOrderModel {
     required this.createdAt,
     this.customerSignatureUrl,
     this.approvedByUid,
+    this.approvedByName,
     this.approvedAt,
     this.rejectionReason,
     this.moldTasksEnabled = false,
@@ -164,6 +166,7 @@ class SalesOrderModel {
       createdAt: data['createdAt'] ?? Timestamp.now(),
       customerSignatureUrl: data['customerSignatureUrl'],
       approvedByUid: data['approvedByUid'],
+      approvedByName: data['approvedByName'],
       approvedAt: data['approvedAt'],
       rejectionReason: data['rejectionReason'],
       moldTasksEnabled: data['moldTasksEnabled'] ?? false,
@@ -195,6 +198,7 @@ class SalesOrderModel {
       'createdAt': createdAt,
       'customerSignatureUrl': customerSignatureUrl,
       'approvedByUid': approvedByUid,
+      'approvedByName': approvedByName,
       'approvedAt': approvedAt,
       'rejectionReason': rejectionReason,
       'moldTasksEnabled': moldTasksEnabled,
@@ -226,6 +230,7 @@ class SalesOrderModel {
     Timestamp? createdAt,
     String? customerSignatureUrl,
     String? approvedByUid,
+    String? approvedByName,
     Timestamp? approvedAt,
     String? rejectionReason,
     bool? moldTasksEnabled,
@@ -255,6 +260,7 @@ class SalesOrderModel {
       createdAt: createdAt ?? this.createdAt,
       customerSignatureUrl: customerSignatureUrl ?? this.customerSignatureUrl,
       approvedByUid: approvedByUid ?? this.approvedByUid,
+      approvedByName: approvedByName ?? this.approvedByName,
       approvedAt: approvedAt ?? this.approvedAt,
       rejectionReason: rejectionReason ?? this.rejectionReason,
       moldTasksEnabled: moldTasksEnabled ?? this.moldTasksEnabled,

--- a/lib/domain/usecases/sales_usecases.dart
+++ b/lib/domain/usecases/sales_usecases.dart
@@ -122,6 +122,7 @@ class SalesUseCases {
     final updatedOrder = order.copyWith(
       status: SalesOrderStatus.pendingFulfillment,
       approvedByUid: accountant.uid,
+      approvedByName: accountant.name,
       approvedAt: Timestamp.now(),
       rejectionReason: null,
       moldTasksEnabled: false,
@@ -165,6 +166,7 @@ class SalesUseCases {
     final updatedOrder = order.copyWith(
       status: SalesOrderStatus.rejected,
       approvedByUid: accountant.uid,
+      approvedByName: accountant.name,
       approvedAt: Timestamp.now(),
       rejectionReason: reason,
       moldTasksEnabled: false,


### PR DESCRIPTION
## Summary
- track the accountant name on sales orders
- include the name when approving or rejecting orders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68568f4d9b04832abb4fcc790c709c38