### PR TITLE
Enable Firestore offline persistence

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,8 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:provider/provider.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 import 'package:plastic_factory_management/theme/app_colors.dart';
@@ -56,8 +58,18 @@ import 'package:plastic_factory_management/presentation/routes/app_router.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  await _configureFirestore();
   runApp(MyApp());
 }
+
+Future<void> _configureFirestore() async {
+  if (kIsWeb) {
+    await FirebaseFirestore.instance.enablePersistence(const PersistenceSettings(synchronizeTabs: true));
+  } else {
+    FirebaseFirestore.instance.settings = const Settings(persistenceEnabled: true, cacheSizeBytes: Settings.CACHE_SIZE_UNLIMITED);
+  }
+}
+
 
 class MyApp extends StatelessWidget {
   @override


### PR DESCRIPTION
## Summary
- use Cloud Firestore offline caching
- enable persistence on mobile and web

## Testing
- `dart format lib/main.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857e5f9ea80832aa16fdb8874c2c026