### PR TITLE
Fix mobile overflow in web index

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -19,9 +19,14 @@
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="description" content="Plastic Factory Management.">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, shrink-to-fit=no, viewport-fit=cover">
   <style>
-    html, body { margin: 0; padding: 0; }
+    html, body {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      overflow-x: hidden;
+    }
   </style>
 
   <!-- iOS meta tags & icons -->


### PR DESCRIPTION
## Summary
- prevent horizontal overflow that was causing blank space on the right side
- update viewport meta tag

## Testing
- `dart format -o write web/index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859110e2128832a9611b42892d0f1d9