### PR TITLE
Fix terms acceptance without UID

### DIFF
--- a/lib/presentation/auth/terms_of_use_screen.dart
+++ b/lib/presentation/auth/terms_of_use_screen.dart
@@ -104,6 +104,14 @@ class TermsOfUseScreen extends StatelessWidget {
                     height: 50, // Set a fixed height for the button
                     child: ElevatedButton.icon(
                       onPressed: () async {
+                        // Don't allow accepting if no user ID provided (before login)
+                        if (uid.isEmpty) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(content: Text('يجب تسجيل الدخول أولاً لقبول الشروط.')),
+                          );
+                          return;
+                        }
+
                         // Show a loading indicator
                         showDialog(
                           context: context,
@@ -118,7 +126,7 @@ class TermsOfUseScreen extends StatelessWidget {
                             Navigator.of(context).pop(); // Dismiss loading indicator
                             // Show a success message
                             ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(content: Text('تم قبول الشروط بنجاح!'),duration: const Duration(seconds: 2),),
+                              SnackBar(content: Text('تم قبول الشروط بنجاح!'), duration: const Duration(seconds: 2)),
                             );
                             Navigator.of(context).pushReplacementNamed(AppRouter.homeRoute);
                           }


### PR DESCRIPTION
## Summary
- avoid calling Firestore with an empty document ID in `TermsOfUseScreen`

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859172101e8832a92c6232ec975a325