### PR TITLE
Fix terms acceptance persistence

### DIFF
--- a/lib/domain/usecases/user_usecases.dart
+++ b/lib/domain/usecases/user_usecases.dart
@@ -46,16 +46,18 @@ class UserUseCases {
     required String name,
     required UserRole role,
     String? employeeId,
-  }) {
+  }) async {
+    final existing = await repository.getUserById(uid);
     final user = UserModel(
       uid: uid,
       email: email,
       name: name,
       role: role.toFirestoreString(),
       employeeId: employeeId,
-      createdAt: Timestamp.now(),
+      createdAt: existing?.createdAt ?? Timestamp.now(),
+      termsAcceptedAt: existing?.termsAcceptedAt,
     );
-    return repository.updateUser(user);
+    await repository.updateUser(user);
   }
 
   Future<void> deleteUser(String uid) {

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -397,6 +397,7 @@
   "acceptTerms": "أوافق على الشروط",
   "termsAcceptedAt": "تاريخ قبول الشروط",
   "notAcceptedYet": "لم يتم القبول بعد",
+  "mustAcceptTerms": "يجب الموافقة على الشروط للمتابعة",
   "loginPrompt": "يرجى تسجيل الدخول للمتابعة.",
   "login": "تسجيل الدخول",
   "tryAgain": "حاول مرة أخرى",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -403,6 +403,7 @@
   "acceptTerms": "Accept Terms",
   "termsAcceptedAt": "Terms accepted on",
   "notAcceptedYet": "Not yet accepted",
+  "mustAcceptTerms": "You must accept the terms to continue",
   "loginPrompt": "Please log in to continue.",
   "login": "Login",
   "tryAgain": "Try Again",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -389,6 +389,8 @@ class AppLocalizations {
   String get acceptTerms => _strings["acceptTerms"] ?? "acceptTerms";
   String get termsAcceptedAt => _strings["termsAcceptedAt"] ?? "termsAcceptedAt";
   String get notAcceptedYet => _strings["notAcceptedYet"] ?? "notAcceptedYet";
+  String get mustAcceptTerms =>
+      _strings["mustAcceptTerms"] ?? "mustAcceptTerms";
   String get loginPrompt => _strings["loginPrompt"] ?? "loginPrompt";
   String get login => _strings["login"] ?? "login";
   String get tryAgain => _strings["tryAgain"] ?? "tryAgain";

--- a/lib/presentation/auth/login_screen.dart
+++ b/lib/presentation/auth/login_screen.dart
@@ -204,6 +204,8 @@ class _LoginScreenState extends State<LoginScreen> with TickerProviderStateMixin
     final user = await _authService.getCurrentUserFirestoreData();
     if (!mounted) return;
 
+    final appLocalizations = AppLocalizations.of(context)!;
+
     if (user != null) {
       if (user.termsAcceptedAt == null) {
         if (_termsAcceptedLocally) {
@@ -211,6 +213,9 @@ class _LoginScreenState extends State<LoginScreen> with TickerProviderStateMixin
           await userUseCases.acceptTerms(user.uid);
           Navigator.of(context).pushReplacementNamed(AppRouter.homeRoute);
         } else {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(appLocalizations.mustAcceptTerms)),
+          );
           Navigator.of(context).pushReplacementNamed(
             AppRouter.termsRoute,
             arguments: user.uid,


### PR DESCRIPTION
## Summary
- preserve users' `termsAcceptedAt` when editing
- show message if login attempted without accepting terms
- add `mustAcceptTerms` localization key in Arabic and English

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a6a2a5b10832a9962cced3e50952f