### PR TITLE
Fix web image uploads

### DIFF
--- a/lib/data/datasources/inventory_datasource.dart
+++ b/lib/data/datasources/inventory_datasource.dart
@@ -5,6 +5,7 @@ import 'package:plastic_factory_management/core/services/file_upload_service.dar
 import 'package:plastic_factory_management/data/models/raw_material_model.dart';
 import 'package:plastic_factory_management/data/models/product_model.dart';
 import 'dart:io';
+import 'dart:typed_data';
 
 class InventoryDatasource {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
@@ -46,11 +47,17 @@ class InventoryDatasource {
     return null;
   }
 
-  Future<void> addProduct(ProductModel product, {File? imageFile}) async {
+  Future<void> addProduct(ProductModel product,
+      {File? imageFile, Uint8List? imageBytes}) async {
     String? imageUrl;
     if (imageFile != null) {
       imageUrl = await _uploadService.uploadFile(
         imageFile,
+        'product_images/${product.productCode}_${DateTime.now().microsecondsSinceEpoch}.jpg',
+      );
+    } else if (imageBytes != null) {
+      imageUrl = await _uploadService.uploadBytes(
+        imageBytes,
         'product_images/${product.productCode}_${DateTime.now().microsecondsSinceEpoch}.jpg',
       );
     }
@@ -58,11 +65,17 @@ class InventoryDatasource {
     // Update the product model with the Firestore generated ID if needed for local use
   }
 
-  Future<void> updateProduct(ProductModel product, {File? newImageFile}) async {
+  Future<void> updateProduct(ProductModel product,
+      {File? newImageFile, Uint8List? newImageBytes}) async {
     String? imageUrl = product.imageUrl; // Keep existing image URL by default
     if (newImageFile != null) {
       imageUrl = await _uploadService.uploadFile(
         newImageFile,
+        'product_images/${product.productCode}_${DateTime.now().microsecondsSinceEpoch}.jpg',
+      );
+    } else if (newImageBytes != null) {
+      imageUrl = await _uploadService.uploadBytes(
+        newImageBytes,
         'product_images/${product.productCode}_${DateTime.now().microsecondsSinceEpoch}.jpg',
       );
     }

--- a/lib/data/repositories/inventory_repository_impl.dart
+++ b/lib/data/repositories/inventory_repository_impl.dart
@@ -3,6 +3,7 @@ import 'package:plastic_factory_management/data/models/raw_material_model.dart';
 import 'package:plastic_factory_management/data/models/product_model.dart';
 import 'package:plastic_factory_management/domain/repositories/inventory_repository.dart';
 import 'dart:io';
+import 'dart:typed_data';
 
 class InventoryRepositoryImpl implements InventoryRepository {
   final InventoryDatasource datasource;
@@ -42,13 +43,17 @@ class InventoryRepositoryImpl implements InventoryRepository {
   }
 
   @override
-  Future<void> addProduct(ProductModel product, {File? imageFile}) {
-    return datasource.addProduct(product, imageFile: imageFile);
+  Future<void> addProduct(ProductModel product,
+      {File? imageFile, Uint8List? imageBytes}) {
+    return datasource.addProduct(product,
+        imageFile: imageFile, imageBytes: imageBytes);
   }
 
   @override
-  Future<void> updateProduct(ProductModel product, {File? newImageFile}) {
-    return datasource.updateProduct(product, newImageFile: newImageFile);
+  Future<void> updateProduct(ProductModel product,
+      {File? newImageFile, Uint8List? newImageBytes}) {
+    return datasource.updateProduct(product,
+        newImageFile: newImageFile, newImageBytes: newImageBytes);
   }
 
   @override

--- a/lib/domain/repositories/inventory_repository.dart
+++ b/lib/domain/repositories/inventory_repository.dart
@@ -3,6 +3,7 @@
 import 'package:plastic_factory_management/data/models/raw_material_model.dart';
 import 'package:plastic_factory_management/data/models/product_model.dart';
 import 'dart:io';
+import 'dart:typed_data';
 
 abstract class InventoryRepository {
   Stream<List<RawMaterialModel>> getRawMaterials();
@@ -12,7 +13,9 @@ abstract class InventoryRepository {
 
   Stream<List<ProductModel>> getProducts();
   Future<ProductModel?> getProductById(String productId);
-  Future<void> addProduct(ProductModel product, {File? imageFile});
-  Future<void> updateProduct(ProductModel product, {File? newImageFile});
+  Future<void> addProduct(ProductModel product,
+      {File? imageFile, Uint8List? imageBytes});
+  Future<void> updateProduct(ProductModel product,
+      {File? newImageFile, Uint8List? newImageBytes});
   Future<void> deleteProduct(String productId);
 }

--- a/lib/domain/usecases/inventory_usecases.dart
+++ b/lib/domain/usecases/inventory_usecases.dart
@@ -4,6 +4,7 @@ import 'package:plastic_factory_management/data/models/raw_material_model.dart';
 import 'package:plastic_factory_management/data/models/product_model.dart';
 import 'package:plastic_factory_management/domain/repositories/inventory_repository.dart';
 import 'dart:io';
+import 'dart:typed_data';
 import 'package:cloud_firestore/cloud_firestore.dart'; // لاستخدام Timestamp
 
 class InventoryUseCases {
@@ -71,6 +72,7 @@ class InventoryUseCases {
     required String name,
     String? description,
     File? imageFile,
+    Uint8List? imageBytes,
     required List<ProductMaterial> billOfMaterials,
     required List<String> colors,
     required List<String> additives,
@@ -94,7 +96,8 @@ class InventoryUseCases {
       productType: productType,
       expectedProductionTimePerUnit: expectedProductionTimePerUnit,
     );
-    await repository.addProduct(newProduct, imageFile: imageFile);
+    await repository.addProduct(newProduct,
+        imageFile: imageFile, imageBytes: imageBytes);
   }
 
   Future<void> updateProduct({
@@ -103,6 +106,7 @@ class InventoryUseCases {
     required String name,
     String? description,
     File? newImageFile,
+    Uint8List? newImageBytes,
     String? existingImageUrl, // لتمرير الرابط الحالي في حال عدم تغيير الصورة
     required List<ProductMaterial> billOfMaterials,
     required List<String> colors,
@@ -128,7 +132,8 @@ class InventoryUseCases {
       productType: productType,
       expectedProductionTimePerUnit: expectedProductionTimePerUnit,
     );
-    await repository.updateProduct(updatedProduct, newImageFile: newImageFile);
+    await repository.updateProduct(updatedProduct,
+        newImageFile: newImageFile, newImageBytes: newImageBytes);
   }
 
   Future<void> deleteProduct(String productId) async {


### PR DESCRIPTION
## Summary
- support passing image bytes when creating/updating products
- fall back to `uploadBytes` on web in inventory datasource
- plumb new parameters through repository and use cases
- handle web image selection in product catalog screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a74029d5c832a976b71efff3c3a88