### PR TITLE
Migrate uploads to Firebase

### DIFF
--- a/lib/core/services/file_upload_service.dart
+++ b/lib/core/services/file_upload_service.dart
@@ -1,31 +1,24 @@
 import 'dart:io';
 import 'dart:typed_data';
-import 'package:http/http.dart' as http;
+import 'package:firebase_storage/firebase_storage.dart';
 
 class FileUploadService {
-  final String baseUrl;
-  FileUploadService({this.baseUrl = 'https://bhbgroup.me/uploads/'});
+  final FirebaseStorage storage;
+
+  FileUploadService({FirebaseStorage? storage})
+      : storage = storage ?? FirebaseStorage.instance;
 
   Future<String?> uploadFile(File file, String path) async {
-    final uri = Uri.parse('$baseUrl$path');
-    final request = http.MultipartRequest('POST', uri)
-      ..files.add(await http.MultipartFile.fromPath('file', file.path));
-    final response = await request.send();
-    if (response.statusCode == 200) {
-      return '$baseUrl$path';
-    }
-    return null;
+    final ref = storage.ref().child(path);
+    final uploadTask = ref.putFile(file);
+    final snapshot = await uploadTask;
+    return snapshot.ref.getDownloadURL();
   }
 
   Future<String?> uploadBytes(Uint8List bytes, String path) async {
-    final uri = Uri.parse('$baseUrl$path');
-    final request = http.MultipartRequest('POST', uri)
-      ..files.add(http.MultipartFile.fromBytes('file', bytes,
-          filename: path.split('/').last));
-    final response = await request.send();
-    if (response.statusCode == 200) {
-      return '$baseUrl$path';
-    }
-    return null;
+    final ref = storage.ref().child(path);
+    final uploadTask = ref.putData(bytes);
+    final snapshot = await uploadTask;
+    return snapshot.ref.getDownloadURL();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   firebase_core: ^2.27.0 # أحدث إصدار متاح حالياً
   firebase_auth: ^4.17.8 # أحدث إصدار متاح حالياً
   cloud_firestore: ^4.15.8 # أحدث إصدار متاح حالياً
+  firebase_storage: ^11.3.0
 
   # UI and Utilities
   image_picker: ^1.0.7 # لاختيار الصور


### PR DESCRIPTION
## Summary
- migrate file upload service to use Firebase Storage
- add firebase_storage to dependencies

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a77b7bff0832aada9f26fdc85b27e