### PR TITLE
Fix Firebase Storage connection on web

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -37,6 +37,12 @@
   <meta name="apple-mobile-web-app-title" content="plastic_factory_management">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
+  <!-- Firebase JS SDK -->
+  <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-storage-compat.js"></script>
+
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 


### PR DESCRIPTION
## Summary
- add Firebase JS SDK scripts for Firebase App, Auth, Firestore, and Storage to `web/index.html`

These scripts are required for FlutterFire web plugins to register correctly and avoid runtime errors like `PlatformException(channel-error, Unable to establish connection on channel.)` when using Firebase Storage on the web.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a7b14b82c832ab36920f2efd5498f