### PR TITLE
Fix currency display in order screens

### DIFF
--- a/lib/presentation/inventory/warehouse_requests_screen.dart
+++ b/lib/presentation/inventory/warehouse_requests_screen.dart
@@ -222,7 +222,7 @@ class _WarehouseRequestsScreenState extends State<WarehouseRequestsScreen> {
                     crossAxisAlignment: CrossAxisAlignment.end,
                   children: [
                       Text(
-                        "${appLocalizations.totalAmount}: \$${order.totalAmount.toStringAsFixed(2)}",
+                        "${appLocalizations.totalAmount}: ريال سعودي ${order.totalAmount.toStringAsFixed(2)}",
                         textDirection: TextDirection.rtl,
                         textAlign: TextAlign.right,
                       ),

--- a/lib/presentation/sales/create_sales_order_screen.dart
+++ b/lib/presentation/sales/create_sales_order_screen.dart
@@ -362,7 +362,7 @@ class _CreateSalesOrderScreenState extends State<CreateSalesOrderScreen> {
                     shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
                     child: ListTile(
                       title: Text(item.productName, textDirection: TextDirection.rtl, style: TextStyle(fontWeight: FontWeight.w600)),
-                      subtitle: Text('${appLocalizations.quantity}: ${item.quantity} | ${appLocalizations.unitPrice}: \$${item.unitPrice.toStringAsFixed(2)}', textDirection: TextDirection.rtl, style: TextStyle(color: Colors.grey[700])),
+                      subtitle: Text('${appLocalizations.quantity}: ${item.quantity} | ${appLocalizations.unitPrice}: ريال سعودي ${item.unitPrice.toStringAsFixed(2)}', textDirection: TextDirection.rtl, style: TextStyle(color: Colors.grey[700])),
                       trailing: Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
@@ -401,7 +401,7 @@ class _CreateSalesOrderScreenState extends State<CreateSalesOrderScreen> {
               Align(
                 alignment: Alignment.centerRight,
                 child: Text(
-                  '${appLocalizations.totalAmount}: ${_totalAmount.toStringAsFixed(2)} ر.س',                  style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold, color: AppColors.primary),
+                  '${appLocalizations.totalAmount}: ريال سعودي ${_totalAmount.toStringAsFixed(2)}',                  style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold, color: AppColors.primary),
                   textDirection: TextDirection.rtl,
                 ),
               ),


### PR DESCRIPTION
## Summary
- display Saudi Riyal text on item price
- show total amount with Saudi Riyal prefix
- update warehouse request list with new currency format

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a87346044832a8c03329323c8da73