### PR TITLE
Add template model and revise raw material structure

### DIFF
--- a/lib/data/datasources/inventory_datasource.dart
+++ b/lib/data/datasources/inventory_datasource.dart
@@ -4,12 +4,37 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:plastic_factory_management/core/services/file_upload_service.dart';
 import 'package:plastic_factory_management/data/models/raw_material_model.dart';
 import 'package:plastic_factory_management/data/models/product_model.dart';
+import 'package:plastic_factory_management/data/models/template_model.dart';
 import 'dart:io';
 import 'dart:typed_data';
 
 class InventoryDatasource {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
   final FileUploadService _uploadService = FileUploadService();
+
+  // --- Template Operations ---
+  Stream<List<TemplateModel>> getTemplates() {
+    return _firestore.collection('templates').snapshots().map((snapshot) {
+      return snapshot.docs
+          .map((doc) => TemplateModel.fromDocumentSnapshot(doc))
+          .toList();
+    });
+  }
+
+  Future<void> addTemplate(TemplateModel template) async {
+    await _firestore.collection('templates').add(template.toMap());
+  }
+
+  Future<void> updateTemplate(TemplateModel template) async {
+    await _firestore
+        .collection('templates')
+        .doc(template.id)
+        .update(template.toMap());
+  }
+
+  Future<void> deleteTemplate(String templateId) async {
+    await _firestore.collection('templates').doc(templateId).delete();
+  }
 
   // --- Raw Materials Operations ---
 

--- a/lib/data/models/product_model.dart
+++ b/lib/data/models/product_model.dart
@@ -40,6 +40,7 @@ class ProductModel {
   final List<ProductMaterial> billOfMaterials; // المواد المستخدمة لإنتاجه مع الكميات
   final List<String> colors; // الألوان المتاحة للمنتج
   final List<String> additives; // الإضافات المطلوبة (مثل مثبتات UV)
+  final List<String> templateIds; // القوالب المستخدمة
   final String packagingType; // نوع التعبئة (مثال: 'صندوق', 'تغليف حراري')
   final bool requiresPackaging; // هل يحتاج المنتج لتعبئة؟
   final bool requiresSticker; // هل يحتاج المنتج لستيكر؟
@@ -55,6 +56,7 @@ class ProductModel {
     required this.billOfMaterials,
     required this.colors,
     required this.additives,
+    this.templateIds = const [],
     required this.packagingType,
     required this.requiresPackaging,
     required this.requiresSticker,
@@ -77,6 +79,7 @@ class ProductModel {
           [],
       colors: List<String>.from(data['colors'] ?? []),
       additives: List<String>.from(data['additives'] ?? []),
+      templateIds: List<String>.from(data['templateIds'] ?? []),
       packagingType: data['packagingType'] ?? '',
       requiresPackaging: data['requiresPackaging'] ?? false,
       requiresSticker: data['requiresSticker'] ?? false,
@@ -95,6 +98,7 @@ class ProductModel {
       'billOfMaterials': billOfMaterials.map((e) => e.toMap()).toList(),
       'colors': colors,
       'additives': additives,
+      'templateIds': templateIds,
       'packagingType': packagingType,
       'requiresPackaging': requiresPackaging,
       'requiresSticker': requiresSticker,
@@ -113,6 +117,7 @@ class ProductModel {
     List<ProductMaterial>? billOfMaterials,
     List<String>? colors,
     List<String>? additives,
+    List<String>? templateIds,
     String? packagingType,
     bool? requiresPackaging,
     bool? requiresSticker,
@@ -128,6 +133,7 @@ class ProductModel {
       billOfMaterials: billOfMaterials ?? this.billOfMaterials,
       colors: colors ?? this.colors,
       additives: additives ?? this.additives,
+      templateIds: templateIds ?? this.templateIds,
       packagingType: packagingType ?? this.packagingType,
       requiresPackaging: requiresPackaging ?? this.requiresPackaging,
       requiresSticker: requiresSticker ?? this.requiresSticker,

--- a/lib/data/models/raw_material_model.dart
+++ b/lib/data/models/raw_material_model.dart
@@ -4,19 +4,17 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 class RawMaterialModel {
   final String id;
+  final String code; // كود المادة
   final String name;
-  final double currentQuantity;
   final String unit; // وحدة القياس، مثل 'kg', 'liter', 'piece'
-  final double minStockLevel; // الحد الأدنى للمخزون (للتنبيهات)
-  final Timestamp lastUpdated;
+  final Timestamp? lastUpdated;
 
   RawMaterialModel({
     required this.id,
+    required this.code,
     required this.name,
-    required this.currentQuantity,
     required this.unit,
-    required this.minStockLevel,
-    required this.lastUpdated,
+    this.lastUpdated,
   });
 
   // Constructor from a Firestore DocumentSnapshot
@@ -24,21 +22,19 @@ class RawMaterialModel {
     final data = doc.data() as Map<String, dynamic>;
     return RawMaterialModel(
       id: doc.id,
+      code: data['code'] ?? '',
       name: data['name'] ?? '',
-      currentQuantity: (data['currentQuantity'] as num?)?.toDouble() ?? 0.0,
       unit: data['unit'] ?? '',
-      minStockLevel: (data['minStockLevel'] as num?)?.toDouble() ?? 0.0,
-      lastUpdated: data['lastUpdated'] ?? Timestamp.now(),
+      lastUpdated: data['lastUpdated'] as Timestamp?,
     );
   }
 
   // Convert RawMaterialModel to a Map for Firestore
   Map<String, dynamic> toMap() {
     return {
+      'code': code,
       'name': name,
-      'currentQuantity': currentQuantity,
       'unit': unit,
-      'minStockLevel': minStockLevel,
       'lastUpdated': lastUpdated,
     };
   }
@@ -46,18 +42,16 @@ class RawMaterialModel {
   // Create a copy with updated values (useful for local state updates before saving)
   RawMaterialModel copyWith({
     String? id,
+    String? code,
     String? name,
-    double? currentQuantity,
     String? unit,
-    double? minStockLevel,
     Timestamp? lastUpdated,
   }) {
     return RawMaterialModel(
       id: id ?? this.id,
+      code: code ?? this.code,
       name: name ?? this.name,
-      currentQuantity: currentQuantity ?? this.currentQuantity,
       unit: unit ?? this.unit,
-      minStockLevel: minStockLevel ?? this.minStockLevel,
       lastUpdated: lastUpdated ?? this.lastUpdated,
     );
   }

--- a/lib/data/models/template_model.dart
+++ b/lib/data/models/template_model.dart
@@ -1,0 +1,97 @@
+// plastic_factory_management/lib/data/models/template_model.dart
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class TemplateMaterial {
+  final String materialId; // مرجع للمادة
+  final double ratio; // النسبة أو الكمية
+
+  TemplateMaterial({required this.materialId, required this.ratio});
+
+  factory TemplateMaterial.fromMap(Map<String, dynamic> map) {
+    return TemplateMaterial(
+      materialId: map['materialId'] ?? '',
+      ratio: (map['ratio'] as num?)?.toDouble() ?? 0.0,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'materialId': materialId,
+      'ratio': ratio,
+    };
+  }
+}
+
+class TemplateModel {
+  final String id; // Firestore document ID
+  final String code; // الكود
+  final String name; // الاسم
+  final double timeRequired; // الوقت المستغرق بالدقائق
+  final List<TemplateMaterial> materialsUsed; // المواد المستخدمة
+  final List<String> colors; // الألوان
+  final double percentage; // النسبة
+  final List<String> additives; // الإضافات
+
+  TemplateModel({
+    required this.id,
+    required this.code,
+    required this.name,
+    required this.timeRequired,
+    required this.materialsUsed,
+    required this.colors,
+    required this.percentage,
+    required this.additives,
+  });
+
+  factory TemplateModel.fromDocumentSnapshot(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return TemplateModel(
+      id: doc.id,
+      code: data['code'] ?? '',
+      name: data['name'] ?? '',
+      timeRequired: (data['timeRequired'] as num?)?.toDouble() ?? 0.0,
+      materialsUsed: (data['materialsUsed'] as List<dynamic>?)
+              ?.map((e) => TemplateMaterial.fromMap(e as Map<String, dynamic>))
+              .toList() ??
+          [],
+      colors: List<String>.from(data['colors'] ?? []),
+      percentage: (data['percentage'] as num?)?.toDouble() ?? 0.0,
+      additives: List<String>.from(data['additives'] ?? []),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'code': code,
+      'name': name,
+      'timeRequired': timeRequired,
+      'materialsUsed': materialsUsed.map((e) => e.toMap()).toList(),
+      'colors': colors,
+      'percentage': percentage,
+      'additives': additives,
+    };
+  }
+
+  TemplateModel copyWith({
+    String? id,
+    String? code,
+    String? name,
+    double? timeRequired,
+    List<TemplateMaterial>? materialsUsed,
+    List<String>? colors,
+    double? percentage,
+    List<String>? additives,
+  }) {
+    return TemplateModel(
+      id: id ?? this.id,
+      code: code ?? this.code,
+      name: name ?? this.name,
+      timeRequired: timeRequired ?? this.timeRequired,
+      materialsUsed: materialsUsed ?? this.materialsUsed,
+      colors: colors ?? this.colors,
+      percentage: percentage ?? this.percentage,
+      additives: additives ?? this.additives,
+    );
+  }
+}

--- a/lib/data/repositories/inventory_repository_impl.dart
+++ b/lib/data/repositories/inventory_repository_impl.dart
@@ -1,6 +1,7 @@
 import 'package:plastic_factory_management/data/datasources/inventory_datasource.dart';
 import 'package:plastic_factory_management/data/models/raw_material_model.dart';
 import 'package:plastic_factory_management/data/models/product_model.dart';
+import 'package:plastic_factory_management/data/models/template_model.dart';
 import 'package:plastic_factory_management/domain/repositories/inventory_repository.dart';
 import 'dart:io';
 import 'dart:typed_data';
@@ -29,6 +30,27 @@ class InventoryRepositoryImpl implements InventoryRepository {
   @override
   Future<void> deleteRawMaterial(String materialId) {
     return datasource.deleteRawMaterial(materialId);
+  }
+
+  // --- Templates ---
+  @override
+  Stream<List<TemplateModel>> getTemplates() {
+    return datasource.getTemplates();
+  }
+
+  @override
+  Future<void> addTemplate(TemplateModel template) {
+    return datasource.addTemplate(template);
+  }
+
+  @override
+  Future<void> updateTemplate(TemplateModel template) {
+    return datasource.updateTemplate(template);
+  }
+
+  @override
+  Future<void> deleteTemplate(String templateId) {
+    return datasource.deleteTemplate(templateId);
   }
 
   // --- Products ---

--- a/lib/domain/repositories/inventory_repository.dart
+++ b/lib/domain/repositories/inventory_repository.dart
@@ -2,6 +2,7 @@
 
 import 'package:plastic_factory_management/data/models/raw_material_model.dart';
 import 'package:plastic_factory_management/data/models/product_model.dart';
+import 'package:plastic_factory_management/data/models/template_model.dart';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -10,6 +11,12 @@ abstract class InventoryRepository {
   Future<void> addRawMaterial(RawMaterialModel material);
   Future<void> updateRawMaterial(RawMaterialModel material);
   Future<void> deleteRawMaterial(String materialId);
+
+  // Template operations
+  Stream<List<TemplateModel>> getTemplates();
+  Future<void> addTemplate(TemplateModel template);
+  Future<void> updateTemplate(TemplateModel template);
+  Future<void> deleteTemplate(String templateId);
 
   Stream<List<ProductModel>> getProducts();
   Future<ProductModel?> getProductById(String productId);

--- a/lib/domain/usecases/inventory_usecases.dart
+++ b/lib/domain/usecases/inventory_usecases.dart
@@ -2,6 +2,7 @@
 
 import 'package:plastic_factory_management/data/models/raw_material_model.dart';
 import 'package:plastic_factory_management/data/models/product_model.dart';
+import 'package:plastic_factory_management/data/models/template_model.dart';
 import 'package:plastic_factory_management/domain/repositories/inventory_repository.dart';
 import 'dart:io';
 import 'dart:typed_data';
@@ -19,17 +20,15 @@ class InventoryUseCases {
   }
 
   Future<void> addRawMaterial({
+    required String code,
     required String name,
-    required double currentQuantity,
     required String unit,
-    required double minStockLevel,
   }) async {
     final newMaterial = RawMaterialModel(
       id: '', // Firestore will generate
+      code: code,
       name: name,
-      currentQuantity: currentQuantity,
       unit: unit,
-      minStockLevel: minStockLevel,
       lastUpdated: Timestamp.now(),
     );
     await repository.addRawMaterial(newMaterial);
@@ -37,17 +36,15 @@ class InventoryUseCases {
 
   Future<void> updateRawMaterial({
     required String id,
+    required String code,
     required String name,
-    required double currentQuantity,
     required String unit,
-    required double minStockLevel,
   }) async {
     final updatedMaterial = RawMaterialModel(
       id: id,
+      code: code,
       name: name,
-      currentQuantity: currentQuantity,
       unit: unit,
-      minStockLevel: minStockLevel,
       lastUpdated: Timestamp.now(),
     );
     await repository.updateRawMaterial(updatedMaterial);
@@ -55,6 +52,64 @@ class InventoryUseCases {
 
   Future<void> deleteRawMaterial(String materialId) async {
     await repository.deleteRawMaterial(materialId);
+  }
+
+  // --- Template Use Cases ---
+  Stream<List<TemplateModel>> getTemplates() {
+    return repository.getTemplates();
+  }
+
+  Future<void> addTemplate({
+    required String code,
+    required String name,
+    required double timeRequired,
+    required List<TemplateMaterial> materialsUsed,
+    required List<String> colors,
+    required double percentage,
+    required List<String> additives,
+    List<String> templateIds = const [],
+  }) async {
+    final newTemplate = TemplateModel(
+      id: '',
+      code: code,
+      name: name,
+      timeRequired: timeRequired,
+      materialsUsed: materialsUsed,
+      colors: colors,
+      percentage: percentage,
+      additives: additives,
+      templateIds: templateIds,
+    );
+    await repository.addTemplate(newTemplate);
+  }
+
+  Future<void> updateTemplate({
+    required String id,
+    required String code,
+    required String name,
+    required double timeRequired,
+    required List<TemplateMaterial> materialsUsed,
+    required List<String> colors,
+    required double percentage,
+    required List<String> additives,
+    List<String>? templateIds,
+  }) async {
+    final updated = TemplateModel(
+      id: id,
+      code: code,
+      name: name,
+      timeRequired: timeRequired,
+      materialsUsed: materialsUsed,
+      colors: colors,
+      percentage: percentage,
+      additives: additives,
+      templateIds: templateIds ?? [],
+    );
+    await repository.updateTemplate(updated);
+  }
+
+  Future<void> deleteTemplate(String templateId) async {
+    await repository.deleteTemplate(templateId);
   }
 
   // --- Product Catalog Use Cases ---
@@ -76,6 +131,7 @@ class InventoryUseCases {
     required List<ProductMaterial> billOfMaterials,
     required List<String> colors,
     required List<String> additives,
+    List<String> templateIds = const [],
     required String packagingType,
     required bool requiresPackaging,
     required bool requiresSticker,
@@ -90,6 +146,7 @@ class InventoryUseCases {
       billOfMaterials: billOfMaterials,
       colors: colors,
       additives: additives,
+      templateIds: templateIds,
       packagingType: packagingType,
       requiresPackaging: requiresPackaging,
       requiresSticker: requiresSticker,
@@ -111,6 +168,7 @@ class InventoryUseCases {
     required List<ProductMaterial> billOfMaterials,
     required List<String> colors,
     required List<String> additives,
+    List<String>? templateIds,
     required String packagingType,
     required bool requiresPackaging,
     required bool requiresSticker,
@@ -126,6 +184,7 @@ class InventoryUseCases {
       billOfMaterials: billOfMaterials,
       colors: colors,
       additives: additives,
+      templateIds: templateIds ?? [],
       packagingType: packagingType,
       requiresPackaging: requiresPackaging,
       requiresSticker: requiresSticker,

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -140,6 +140,7 @@
   "errorRejectingStage": "خطأ في رفض المرحلة: ",
   "addRawMaterial": "إضافة مادة أولية",
   "editRawMaterial": "تعديل مادة أولية",
+  "materialCode": "كود المادة",
   "materialName": "اسم المادة",
   "add": "إضافة",
   "save": "حفظ",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -176,6 +176,7 @@
   "errorRejectingStage": "خطأ في رفض المرحلة: ",
   "addRawMaterial": "إضافة مادة أولية",
   "editRawMaterial": "تعديل مادة أولية",
+  "materialCode": "كود المادة",
   "materialName": "اسم المادة",
   "add": "إضافة",
   "save": "حفظ",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -157,6 +157,7 @@ class AppLocalizations {
   String get errorRejectingStage => _strings["errorRejectingStage"] ?? "errorRejectingStage";
   String get addRawMaterial => _strings["addRawMaterial"] ?? "addRawMaterial";
   String get editRawMaterial => _strings["editRawMaterial"] ?? "editRawMaterial";
+  String get materialCode => _strings["materialCode"] ?? "materialCode";
   String get materialName => _strings["materialName"] ?? "materialName";
   String get add => _strings["add"] ?? "add";
   String get save => _strings["save"] ?? "save";


### PR DESCRIPTION
## Summary
- introduce `TemplateModel` for mold templates
- simplify `RawMaterialModel` to hold code, name and unit only
- expose template CRUD methods in inventory layer
- allow products to reference template IDs
- update inventory screens and localization strings

## Testing
- `dart` and `flutter` commands were unavailable, so formatting and tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_6862506990a8832a8599a993c0f603d0