### PR TITLE
Add templates selection for products

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -54,6 +54,8 @@
   "materialsUsed": "المواد المستخدمة لإنتاجه",
   "colors": "الألوان",
   "additives": "إضافات",
+  "templates": "القوالب",
+  "selectTemplate": "اختر القالب",
   "packagingType": "نوع التعبئة",
   "requiresPackaging": "هل يحتاج تغليف؟",
   "requiresSticker": "هل يحتاج ستيكر؟",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -87,6 +87,8 @@
   "materialsUsed": "المواد المستخدمة لإنتاجه",
   "colors": "الألوان",
   "additives": "إضافات",
+  "templates": "القوالب",
+  "selectTemplate": "اختر القالب",
   "packagingType": "نوع التعبئة",
   "requiresPackaging": "هل يحتاج تغليف؟",
   "requiresSticker": "هل يحتاج ستيكر؟",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -71,6 +71,8 @@ class AppLocalizations {
   String get materialsUsed => _strings["materialsUsed"] ?? "materialsUsed";
   String get colors => _strings["colors"] ?? "colors";
   String get additives => _strings["additives"] ?? "additives";
+  String get templates => _strings["templates"] ?? "templates";
+  String get selectTemplate => _strings["selectTemplate"] ?? "selectTemplate";
   String get packagingType => _strings["packagingType"] ?? "packagingType";
   String get requiresPackaging => _strings["requiresPackaging"] ?? "requiresPackaging";
   String get requiresSticker => _strings["requiresSticker"] ?? "requiresSticker";


### PR DESCRIPTION
## Summary
- allow mapping template IDs to names in product catalog screen
- show templates in product details dialog
- add templates selection when adding/editing a product
- support template IDs in product save operations
- add Arabic localization for template labels

## Testing
- `flutter gen-l10n` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68625f9f51d0832a899bf52640516225