### PR TITLE
Add templates section access

### DIFF
--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -316,6 +316,15 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
 
       modules.add(_buildModuleButton(
         context: context,
+        title: appLocalizations.templates,
+        subtitle: "إدارة القوالب",
+        icon: Icons.view_module,
+        color: moduleColors['inventory']!,
+        onPressed: () => Navigator.of(context).pushNamed(AppRouter.templatesRoute),
+      ));
+
+      modules.add(_buildModuleButton(
+        context: context,
         title: appLocalizations.machineProfiles,
         subtitle: "ملفات الآلات",
         icon: Icons.precision_manufacturing,


### PR DESCRIPTION
## Summary
- add link to Templates screen for factory manager on home screen

## Testing
- `dart format lib/presentation/home/home_screen.dart` *(fails: dart not found)*
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_68627d28f6d4832a858f819c5570f6d4