### PR TITLE
Fix dropdown value state for material selection

### DIFF
--- a/lib/data/models/raw_material_model.dart
+++ b/lib/data/models/raw_material_model.dart
@@ -55,4 +55,13 @@ class RawMaterialModel {
       lastUpdated: lastUpdated ?? this.lastUpdated,
     );
   }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is RawMaterialModel && other.id == id;
+  }
+
+  @override
+  int get hashCode => id.hashCode;
 }

--- a/lib/presentation/inventory/templates_screen.dart
+++ b/lib/presentation/inventory/templates_screen.dart
@@ -317,9 +317,10 @@ class _TemplatesScreenState extends State<TemplatesScreen> {
               title: Text(appLocalizations.addMaterial),
               content: Form(
                 key: _formKey,
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
+                child: SingleChildScrollView(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
                     StreamBuilder<List<RawMaterialModel>>(
                       stream: useCases.getRawMaterials(),
                       builder: (context, snapshot) {


### PR DESCRIPTION
## Summary
- prevent overflow in add-material dialog by wrapping content in `SingleChildScrollView`
- make `RawMaterialModel` equatable so dropdown selection works after stream updates

## Testing
- `No automated tests run - flutter and dart unavailable`

------
https://chatgpt.com/codex/tasks/task_e_686283565c70832a81ffbe9b3c2e67bd