### PR TITLE
Display template details when product card tapped

### DIFF
--- a/lib/domain/usecases/inventory_usecases.dart
+++ b/lib/domain/usecases/inventory_usecases.dart
@@ -108,6 +108,11 @@ class InventoryUseCases {
     await repository.deleteTemplate(templateId);
   }
 
+  Future<List<TemplateModel>> getTemplatesByIds(List<String> ids) async {
+    final all = await repository.getTemplates().first;
+    return all.where((t) => ids.contains(t.id)).toList();
+  }
+
   // --- Product Catalog Use Cases ---
 
   Stream<List<ProductModel>> getProducts() {


### PR DESCRIPTION
## Summary
- add `getTemplatesByIds` helper in use cases
- show template details instead of product details when templates exist

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68628f92d36c832aab4a21d898fe821f