### PR TITLE
Add admin modules for additional sections

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -414,5 +414,10 @@
   "login": "تسجيل الدخول",
   "tryAgain": "حاول مرة أخرى",
   "clearFilter": "مسح الفلتر",
-  "orderId": "رقم الطلب"
+  "orderId": "رقم الطلب",
+  "returns": "المرتجع",
+  "delivery": "التوصيل",
+  "reports": "التقارير",
+  "procurement": "المشتريات",
+  "documentCenter": "مركز الوثائق والسياسات"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -421,5 +421,10 @@
   "tryAgain": "Try Again",
   "clearFilter": "Clear Filter",
   "orderId": "Order ID",
+  "returns": "Returns",
+  "delivery": "Delivery",
+  "reports": "Reports",
+  "procurement": "Procurement",
+  "documentCenter": "Documents & Policies",
   "unknown": "Unknown"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -408,6 +408,11 @@ class AppLocalizations {
   String get percentage => _strings["percentage"] ?? "percentage";
   String get noTemplatesAvailable => _strings["noTemplatesAvailable"] ?? "noTemplatesAvailable";
   String get tapToAddFirstTemplate => _strings["tapToAddFirstTemplate"] ?? "tapToAddFirstTemplate";
+  String get returns => _strings["returns"] ?? "returns";
+  String get delivery => _strings["delivery"] ?? "delivery";
+  String get reports => _strings["reports"] ?? "reports";
+  String get procurement => _strings["procurement"] ?? "procurement";
+  String get documentCenter => _strings["documentCenter"] ?? "documentCenter";
 
 
 }

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -282,6 +282,11 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
       'management': const Color(0xFF5D4037),
       'quality': const Color(0xFF0097A7),
       'accounting': const Color(0xFF455A64),
+      'returns': const Color(0xFF795548),
+      'delivery': const Color(0xFF00838F),
+      'reports': const Color(0xFF512DA8),
+      'procurement': const Color(0xFF388E3C),
+      'documents': const Color(0xFF283593),
     };
 
     // Modules for Factory Manager (مدير المصنع) - Full Access
@@ -377,6 +382,51 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
         icon: Icons.manage_accounts,
         color: moduleColors['management']!,
         onPressed: () => Navigator.of(context).pushNamed(AppRouter.userManagementRoute),
+      ));
+
+      modules.add(_buildModuleButton(
+        context: context,
+        title: appLocalizations.returns,
+        subtitle: "إدارة المرتجعات",
+        icon: Icons.assignment_return,
+        color: moduleColors['returns']!,
+        onPressed: () => Navigator.of(context).pushNamed(AppRouter.returnsRoute),
+      ));
+
+      modules.add(_buildModuleButton(
+        context: context,
+        title: appLocalizations.delivery,
+        subtitle: "شحن المنتجات",
+        icon: Icons.local_shipping,
+        color: moduleColors['delivery']!,
+        onPressed: () => Navigator.of(context).pushNamed(AppRouter.deliveryRoute),
+      ));
+
+      modules.add(_buildModuleButton(
+        context: context,
+        title: appLocalizations.reports,
+        subtitle: "التقارير والإحصائيات",
+        icon: Icons.bar_chart,
+        color: moduleColors['reports']!,
+        onPressed: () => Navigator.of(context).pushNamed(AppRouter.reportsRoute),
+      ));
+
+      modules.add(_buildModuleButton(
+        context: context,
+        title: appLocalizations.procurement,
+        subtitle: "إدارة المشتريات",
+        icon: Icons.shopping_bag,
+        color: moduleColors['procurement']!,
+        onPressed: () => Navigator.of(context).pushNamed(AppRouter.procurementRoute),
+      ));
+
+      modules.add(_buildModuleButton(
+        context: context,
+        title: appLocalizations.documentCenter,
+        subtitle: "توثيق وسياسات",
+        icon: Icons.policy,
+        color: moduleColors['documents']!,
+        onPressed: () => Navigator.of(context).pushNamed(AppRouter.documentsCenterRoute),
       ));
     }
 

--- a/lib/presentation/management/delivery_screen.dart
+++ b/lib/presentation/management/delivery_screen.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:plastic_factory_management/l10n/app_localizations.dart';
+
+class DeliveryScreen extends StatelessWidget {
+  const DeliveryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final appLocalizations = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(appLocalizations.delivery),
+        centerTitle: true,
+      ),
+      body: Center(
+        child: Text(
+          'هنا إدارة عمليات التوصيل',
+          textDirection: TextDirection.rtl,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/management/documents_center_screen.dart
+++ b/lib/presentation/management/documents_center_screen.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:plastic_factory_management/l10n/app_localizations.dart';
+
+class DocumentsCenterScreen extends StatelessWidget {
+  const DocumentsCenterScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final appLocalizations = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(appLocalizations.documentCenter),
+        centerTitle: true,
+      ),
+      body: Center(
+        child: Text(
+          'هنا مركز الوثائق والسياسات',
+          textDirection: TextDirection.rtl,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/management/procurement_screen.dart
+++ b/lib/presentation/management/procurement_screen.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:plastic_factory_management/l10n/app_localizations.dart';
+
+class ProcurementScreen extends StatelessWidget {
+  const ProcurementScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final appLocalizations = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(appLocalizations.procurement),
+        centerTitle: true,
+      ),
+      body: Center(
+        child: Text(
+          'هنا إدارة عمليات المشتريات',
+          textDirection: TextDirection.rtl,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/management/reports_screen.dart
+++ b/lib/presentation/management/reports_screen.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:plastic_factory_management/l10n/app_localizations.dart';
+
+class ReportsScreen extends StatelessWidget {
+  const ReportsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final appLocalizations = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(appLocalizations.reports),
+        centerTitle: true,
+      ),
+      body: Center(
+        child: Text(
+          'هنا عرض التقارير والإحصائيات',
+          textDirection: TextDirection.rtl,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/management/returns_screen.dart
+++ b/lib/presentation/management/returns_screen.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:plastic_factory_management/l10n/app_localizations.dart';
+
+class ReturnsScreen extends StatelessWidget {
+  const ReturnsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final appLocalizations = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(appLocalizations.returns),
+        centerTitle: true,
+      ),
+      body: Center(
+        child: Text(
+          'هنا يمكن إدارة عمليات المرتجع',
+          textDirection: TextDirection.rtl,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/routes/app_router.dart
+++ b/lib/presentation/routes/app_router.dart
@@ -22,6 +22,11 @@ import 'package:plastic_factory_management/presentation/inventory/warehouse_requ
 import 'package:plastic_factory_management/presentation/accounting/accounting_screen.dart';
 import 'package:plastic_factory_management/presentation/notifications/notifications_screen.dart';
 import 'package:plastic_factory_management/presentation/management/user_management_screen.dart';
+import 'package:plastic_factory_management/presentation/management/returns_screen.dart';
+import 'package:plastic_factory_management/presentation/management/delivery_screen.dart';
+import 'package:plastic_factory_management/presentation/management/reports_screen.dart';
+import 'package:plastic_factory_management/presentation/management/procurement_screen.dart';
+import 'package:plastic_factory_management/presentation/management/documents_center_screen.dart';
 
 
 class AppRouter {
@@ -45,6 +50,11 @@ class AppRouter {
   static const String warehouseRequestsRoute = '/inventory/warehouse_requests';
   static const String accountingRoute = '/accounting';
   static const String userManagementRoute = '/management/users';
+  static const String returnsRoute = '/management/returns';
+  static const String deliveryRoute = '/management/delivery';
+  static const String reportsRoute = '/management/reports';
+  static const String procurementRoute = '/management/procurement';
+  static const String documentsCenterRoute = '/management/documents';
   static const String notificationsRoute = '/notifications';
 
   static Route<dynamic> generateRoute(RouteSettings settings) {
@@ -87,6 +97,16 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => AccountingScreen());
       case userManagementRoute:
         return MaterialPageRoute(builder: (_) => UserManagementScreen());
+      case returnsRoute:
+        return MaterialPageRoute(builder: (_) => ReturnsScreen());
+      case deliveryRoute:
+        return MaterialPageRoute(builder: (_) => DeliveryScreen());
+      case reportsRoute:
+        return MaterialPageRoute(builder: (_) => ReportsScreen());
+      case procurementRoute:
+        return MaterialPageRoute(builder: (_) => ProcurementScreen());
+      case documentsCenterRoute:
+        return MaterialPageRoute(builder: (_) => DocumentsCenterScreen());
       case termsRoute:
         final uid = settings.arguments as String;
         return MaterialPageRoute(


### PR DESCRIPTION
## Summary
- add new screens for returns, delivery, reports, procurement and document center
- register new routes in `AppRouter`
- show new modules for the factory manager on the home screen
- update localization files with new labels

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68640c15f9c8832ab2b06e9ec0a9b658