### PR TITLE
Add Production Board screen

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -63,7 +63,12 @@
   "timeRequired": "الوقت المستغرق",
   "percentage": "النسبة",
   "noTemplatesAvailable": "لا توجد قوالب متاحة.",
-    "tapToAddFirstTemplate": "اضغط على زر '+' لإضافة أول قالب.",
+  "tapToAddFirstTemplate": "اضغط على زر '+' لإضافة أول قالب.",
+
+  "productionBoard": "لوحة الإنتاج",
+  "issueProductionOrders": "إصدار أوامر الإنتاج وربطها بالقوالب والماكينات",
+  "trackDefectsShifts": "تتبع التالف والورديات ومراقبة الأداء",
+  "logMoldReceipt": "تسجيل استلام القوالب، التوجيه، التشغيل والتسليم",
 
   "selectTemplate": "اختر القالب",
   "packagingType": "نوع التعبئة",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -96,7 +96,12 @@
   "timeRequired": "الوقت المستغرق",
   "percentage": "النسبة",
   "noTemplatesAvailable": "لا توجد قوالب متاحة.",
-    "tapToAddFirstTemplate": "اضغط على زر '+' لإضافة أول قالب.",
+  "tapToAddFirstTemplate": "اضغط على زر '+' لإضافة أول قالب.",
+
+  "productionBoard": "Production Board",
+  "issueProductionOrders": "Issue production orders linked to molds and machines",
+  "trackDefectsShifts": "Track defects, shifts, and monitor performance",
+  "logMoldReceipt": "Log mold receipt, orientation, operation and delivery",
 
   "selectTemplate": "اختر القالب",
   "packagingType": "نوع التعبئة",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -409,6 +409,10 @@ class AppLocalizations {
   String get percentage => _strings["percentage"] ?? "percentage";
   String get noTemplatesAvailable => _strings["noTemplatesAvailable"] ?? "noTemplatesAvailable";
   String get tapToAddFirstTemplate => _strings["tapToAddFirstTemplate"] ?? "tapToAddFirstTemplate";
+  String get productionBoard => _strings["productionBoard"] ?? "productionBoard";
+  String get issueProductionOrders => _strings["issueProductionOrders"] ?? "issueProductionOrders";
+  String get trackDefectsShifts => _strings["trackDefectsShifts"] ?? "trackDefectsShifts";
+  String get logMoldReceipt => _strings["logMoldReceipt"] ?? "logMoldReceipt";
   String get returns => _strings["returns"] ?? "returns";
   String get delivery => _strings["delivery"] ?? "delivery";
   String get reports => _strings["reports"] ?? "reports";

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -357,6 +357,15 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
 
       modules.add(_buildModuleButton(
         context: context,
+        title: appLocalizations.productionBoard,
+        subtitle: "وحدة الإنتاج",
+        icon: Icons.dashboard,
+        color: moduleColors['production']!,
+        onPressed: () => Navigator.of(context).pushNamed(AppRouter.productionBoardRoute),
+      ));
+
+      modules.add(_buildModuleButton(
+        context: context,
         title: appLocalizations.operatorProfiles,
         subtitle: "ملفات المشغلين",
         icon: Icons.people,

--- a/lib/presentation/production/production_board_screen.dart
+++ b/lib/presentation/production/production_board_screen.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:plastic_factory_management/l10n/app_localizations.dart';
+import 'package:plastic_factory_management/presentation/routes/app_router.dart';
+
+class ProductionBoardScreen extends StatelessWidget {
+  const ProductionBoardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final appLocalizations = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(appLocalizations.productionBoard),
+        centerTitle: true,
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(20),
+        children: [
+          ListTile(
+            leading: const Icon(Icons.add_circle_outline),
+            title: Text(
+              appLocalizations.issueProductionOrders,
+              textDirection: TextDirection.rtl,
+            ),
+            onTap: () {
+              Navigator.of(context).pushNamed(AppRouter.createProductionOrderRoute);
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.analytics_outlined),
+            title: Text(
+              appLocalizations.trackDefectsShifts,
+              textDirection: TextDirection.rtl,
+            ),
+            onTap: () {
+              Navigator.of(context).pushNamed(AppRouter.productionOrdersListRoute);
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.assignment_turned_in_outlined),
+            title: Text(
+              appLocalizations.logMoldReceipt,
+              textDirection: TextDirection.rtl,
+            ),
+            onTap: () {
+              Navigator.of(context).pushNamed(AppRouter.productionOrdersListRoute);
+            },
+          ),
+          const SizedBox(height: 20),
+          Center(
+            child: Text(
+              'هنا يمكن لمدير المصنع متابعة مهام الإنتاج وإصدار الأوامر.',
+              textAlign: TextAlign.center,
+              textDirection: TextDirection.rtl,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/routes/app_router.dart
+++ b/lib/presentation/routes/app_router.dart
@@ -6,6 +6,7 @@ import 'package:plastic_factory_management/presentation/auth/terms_of_use_screen
 import 'package:plastic_factory_management/presentation/home/home_screen.dart';
 import 'package:plastic_factory_management/presentation/production/create_production_order_screen.dart';
 import 'package:plastic_factory_management/presentation/production/production_orders_list_screen.dart';
+import 'package:plastic_factory_management/presentation/production/production_board_screen.dart';
 import 'package:plastic_factory_management/presentation/inventory/raw_materials_screen.dart';
 import 'package:plastic_factory_management/presentation/inventory/product_catalog_screen.dart'; // يمكن إعادة استخدامها
 import 'package:plastic_factory_management/presentation/inventory/templates_screen.dart';
@@ -35,6 +36,7 @@ class AppRouter {
   static const String termsRoute = '/terms';
   static const String createProductionOrderRoute = '/production/create';
   static const String productionOrdersListRoute = '/production/list';
+  static const String productionBoardRoute = '/production/board';
   static const String rawMaterialsRoute = '/inventory/raw_materials';
   static const String productCatalogRoute = '/inventory/product_catalog';
   static const String templatesRoute = '/inventory/templates';
@@ -67,6 +69,8 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => CreateProductionOrderScreen());
       case productionOrdersListRoute:
         return MaterialPageRoute(builder: (_) => ProductionOrdersListScreen());
+      case productionBoardRoute:
+        return MaterialPageRoute(builder: (_) => const ProductionBoardScreen());
       case rawMaterialsRoute:
         return MaterialPageRoute(builder: (_) => RawMaterialsScreen());
       case productCatalogRoute:


### PR DESCRIPTION
## Summary
- add strings for Production Board features
- expose Production Board localizations
- create `ProductionBoardScreen`
- route `/production/board` for the new screen
- link Production Board from home screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686431804248832aa6401ec3b00d1200