### PR TITLE
Fix TemplateModel dropdown equality

### DIFF
--- a/lib/data/models/template_model.dart
+++ b/lib/data/models/template_model.dart
@@ -94,4 +94,13 @@ class TemplateModel {
       additives: additives ?? this.additives,
     );
   }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is TemplateModel && other.id == id;
+  }
+
+  @override
+  int get hashCode => id.hashCode;
 }


### PR DESCRIPTION
## Summary
- implement equality and hashCode for `TemplateModel` to compare by id

## Testing
- `dart`/`flutter` commands were not available so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_6864354bde0c832aa43db7bf91cfcb0a