### PR TITLE
Add template and machine details to order view

### DIFF
--- a/lib/data/datasources/inventory_datasource.dart
+++ b/lib/data/datasources/inventory_datasource.dart
@@ -36,6 +36,14 @@ class InventoryDatasource {
     await _firestore.collection('templates').doc(templateId).delete();
   }
 
+  Future<TemplateModel?> getTemplateById(String templateId) async {
+    final doc = await _firestore.collection('templates').doc(templateId).get();
+    if (doc.exists) {
+      return TemplateModel.fromDocumentSnapshot(doc);
+    }
+    return null;
+  }
+
   // --- Raw Materials Operations ---
 
   Stream<List<RawMaterialModel>> getRawMaterials() {

--- a/lib/data/repositories/inventory_repository_impl.dart
+++ b/lib/data/repositories/inventory_repository_impl.dart
@@ -53,6 +53,11 @@ class InventoryRepositoryImpl implements InventoryRepository {
     return datasource.deleteTemplate(templateId);
   }
 
+  @override
+  Future<TemplateModel?> getTemplateById(String templateId) {
+    return datasource.getTemplateById(templateId);
+  }
+
   // --- Products ---
   @override
   Stream<List<ProductModel>> getProducts() {

--- a/lib/domain/repositories/inventory_repository.dart
+++ b/lib/domain/repositories/inventory_repository.dart
@@ -17,6 +17,7 @@ abstract class InventoryRepository {
   Future<void> addTemplate(TemplateModel template);
   Future<void> updateTemplate(TemplateModel template);
   Future<void> deleteTemplate(String templateId);
+  Future<TemplateModel?> getTemplateById(String templateId);
 
   Stream<List<ProductModel>> getProducts();
   Future<ProductModel?> getProductById(String productId);

--- a/lib/domain/usecases/inventory_usecases.dart
+++ b/lib/domain/usecases/inventory_usecases.dart
@@ -108,6 +108,10 @@ class InventoryUseCases {
     await repository.deleteTemplate(templateId);
   }
 
+  Future<TemplateModel?> getTemplateById(String templateId) {
+    return repository.getTemplateById(templateId);
+  }
+
   Future<List<TemplateModel>> getTemplatesByIds(List<String> ids) async {
     final all = await repository.getTemplates().first;
     return all.where((t) => ids.contains(t.id)).toList();

--- a/lib/domain/usecases/machinery_operator_usecases.dart
+++ b/lib/domain/usecases/machinery_operator_usecases.dart
@@ -60,6 +60,10 @@ class MachineryOperatorUseCases {
     await repository.deleteMachine(machineId);
   }
 
+  Future<MachineModel?> getMachineById(String machineId) {
+    return repository.getMachineById(machineId);
+  }
+
   // --- Operator Use Cases ---
 
   Stream<List<OperatorModel>> getOperators() {

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -60,6 +60,7 @@
   "editTemplate": "تعديل قالب",
   "templateCode": "كود القالب",
   "templateName": "اسم القالب",
+  "templateDetails": "تفاصيل القالب",
   "timeRequired": "الوقت المستغرق",
   "percentage": "النسبة",
   "noTemplatesAvailable": "لا توجد قوالب متاحة.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -93,6 +93,7 @@
   "editTemplate": "تعديل قالب",
   "templateCode": "كود القالب",
   "templateName": "اسم القالب",
+  "templateDetails": "تفاصيل القالب",
   "timeRequired": "الوقت المستغرق",
   "percentage": "النسبة",
   "noTemplatesAvailable": "لا توجد قوالب متاحة.",


### PR DESCRIPTION
## Summary
- add `templateDetails` string
- fetch template by ID
- expose `getTemplateById` repository and usecase methods
- expose `getMachineById` usecase method
- show mold and machine details on production order detail screen

## Testing
- `dart` or `flutter` were not available so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_686437be4c80832a880467caf742a65e