### PR TITLE
Add missing templateDetails localization getter

### DIFF
--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -406,6 +406,7 @@ class AppLocalizations {
   String get editTemplate => _strings["editTemplate"] ?? "editTemplate";
   String get templateCode => _strings["templateCode"] ?? "templateCode";
   String get templateName => _strings["templateName"] ?? "templateName";
+  String get templateDetails => _strings["templateDetails"] ?? "templateDetails";
   String get timeRequired => _strings["timeRequired"] ?? "timeRequired";
   String get percentage => _strings["percentage"] ?? "percentage";
   String get noTemplatesAvailable => _strings["noTemplatesAvailable"] ?? "noTemplatesAvailable";


### PR DESCRIPTION
## Summary
- ensure `templateDetails` key is exposed in the generated localizations file

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686439f0e82c832a83b2e3d0d36d7f4e