### PR TITLE
Filter to show last created order

### DIFF
--- a/lib/domain/usecases/production_order_usecases.dart
+++ b/lib/domain/usecases/production_order_usecases.dart
@@ -68,7 +68,7 @@ class ProductionOrderUseCases {
   }
 
   // Use case to create a new production order
-  Future<void> createProductionOrder({
+  Future<ProductionOrderModel> createProductionOrder({
     required ProductModel selectedProduct,
     required int requiredQuantity,
     required String batchNumber,
@@ -130,6 +130,8 @@ class ProductionOrderUseCases {
         );
       }
     }
+
+    return createdOrder;
   }
 
   // Create production orders from a sales order (one per item)

--- a/lib/presentation/production/create_production_order_screen.dart
+++ b/lib/presentation/production/create_production_order_screen.dart
@@ -57,7 +57,7 @@ class _CreateProductionOrderScreenState extends State<CreateProductionOrderScree
       });
 
       try {
-        await useCases.createProductionOrder(
+        final createdOrder = await useCases.createProductionOrder(
           selectedProduct: _selectedProduct!,
           requiredQuantity: int.parse(_quantityController.text),
           batchNumber: _batchNumberController.text,
@@ -68,7 +68,7 @@ class _CreateProductionOrderScreenState extends State<CreateProductionOrderScree
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(AppLocalizations.of(context)!.orderCreatedSuccessfully)), // إضافة هذا النص في ARB
         );
-        Navigator.of(context).pop(); // العودة بعد الإرسال الناجح
+        Navigator.of(context).pop(createdOrder); // العودة بعد الإرسال الناجح مع الطلب الجديد
       } catch (e) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('${AppLocalizations.of(context)!.errorCreatingOrder}: $e')), // إضافة هذا النص في ARB

--- a/lib/presentation/production/production_orders_list_screen.dart
+++ b/lib/presentation/production/production_orders_list_screen.dart
@@ -23,6 +23,7 @@ class ProductionOrdersListScreen extends StatefulWidget {
 
 class _ProductionOrdersListScreenState extends State<ProductionOrdersListScreen> {
   String _selectedStatusFilter = 'all';
+  ProductionOrderModel? _newlyCreatedOrder;
 
   @override
   Widget build(BuildContext context) {
@@ -77,8 +78,16 @@ class _ProductionOrdersListScreenState extends State<ProductionOrdersListScreen>
           if (isPreparer)
             IconButton(
               icon: Icon(Icons.add, color: Colors.white), // White icon
-              onPressed: () {
-                Navigator.of(context).push(MaterialPageRoute(builder: (_) => CreateProductionOrderScreen()));
+              onPressed: () async {
+                final newOrder = await Navigator.of(context).push<ProductionOrderModel?>(
+                  MaterialPageRoute(builder: (_) => CreateProductionOrderScreen()),
+                );
+                if (newOrder != null) {
+                  setState(() {
+                    _newlyCreatedOrder = newOrder;
+                    _selectedStatusFilter = 'all';
+                  });
+                }
               },
               tooltip: appLocalizations.createOrder,
             ),
@@ -188,8 +197,16 @@ class _ProductionOrdersListScreenState extends State<ProductionOrdersListScreen>
                           if (isPreparer) const SizedBox(height: 24),
                           if (isPreparer)
                             ElevatedButton.icon(
-                              onPressed: () {
-                                Navigator.of(context).push(MaterialPageRoute(builder: (_) => CreateProductionOrderScreen()));
+                              onPressed: () async {
+                                final newOrder = await Navigator.of(context).push<ProductionOrderModel?>(
+                                  MaterialPageRoute(builder: (_) => CreateProductionOrderScreen()),
+                                );
+                                if (newOrder != null) {
+                                  setState(() {
+                                    _newlyCreatedOrder = newOrder;
+                                    _selectedStatusFilter = 'all';
+                                  });
+                                }
                               },
                               icon: const Icon(Icons.add),
                               label: Text(appLocalizations.createOrder),
@@ -212,6 +229,14 @@ class _ProductionOrdersListScreenState extends State<ProductionOrdersListScreen>
                 List<ProductionOrderModel> orders = snapshot.data!
                     .where((order) => order.salesOrderId == null || order.salesOrderId!.isEmpty)
                     .toList();
+
+                if (_newlyCreatedOrder != null) {
+                  final exists = orders.any((o) => o.id == _newlyCreatedOrder!.id);
+                  if (!exists) {
+                    orders = [ _newlyCreatedOrder!, ...orders ];
+                  }
+                  orders = orders.where((o) => o.id == _newlyCreatedOrder!.id).toList();
+                }
 
                 List<ProductionOrderModel> filteredOrders = isPreparer
                     ? orders.where((order) => order.orderPreparerUid == currentUser.uid).toList()


### PR DESCRIPTION
## Summary
- expose created order from `ProductionOrderUseCases.createProductionOrder`
- return the created order when closing the create order screen
- display only the recently created order when navigating back to the orders list

## Testing
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686444a63d4c832a9f1d786863fd41ac