### PR TITLE
Fix production orders filtering

### DIFF
--- a/lib/presentation/production/create_production_order_screen.dart
+++ b/lib/presentation/production/create_production_order_screen.dart
@@ -57,7 +57,7 @@ class _CreateProductionOrderScreenState extends State<CreateProductionOrderScree
       });
 
       try {
-        final createdOrder = await useCases.createProductionOrder(
+        await useCases.createProductionOrder(
           selectedProduct: _selectedProduct!,
           requiredQuantity: int.parse(_quantityController.text),
           batchNumber: _batchNumberController.text,
@@ -68,7 +68,7 @@ class _CreateProductionOrderScreenState extends State<CreateProductionOrderScree
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(AppLocalizations.of(context)!.orderCreatedSuccessfully)), // إضافة هذا النص في ARB
         );
-        Navigator.of(context).pop(createdOrder); // العودة بعد الإرسال الناجح مع الطلب الجديد
+        Navigator.of(context).pop(); // العودة بعد الإرسال الناجح
       } catch (e) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('${AppLocalizations.of(context)!.errorCreatingOrder}: $e')), // إضافة هذا النص في ARB

--- a/lib/presentation/production/production_orders_list_screen.dart
+++ b/lib/presentation/production/production_orders_list_screen.dart
@@ -23,7 +23,6 @@ class ProductionOrdersListScreen extends StatefulWidget {
 
 class _ProductionOrdersListScreenState extends State<ProductionOrdersListScreen> {
   String _selectedStatusFilter = 'all';
-  ProductionOrderModel? _newlyCreatedOrder;
 
   @override
   Widget build(BuildContext context) {
@@ -78,16 +77,10 @@ class _ProductionOrdersListScreenState extends State<ProductionOrdersListScreen>
           if (isPreparer)
             IconButton(
               icon: Icon(Icons.add, color: Colors.white), // White icon
-              onPressed: () async {
-                final newOrder = await Navigator.of(context).push<ProductionOrderModel?>(
+              onPressed: () {
+                Navigator.of(context).push(
                   MaterialPageRoute(builder: (_) => CreateProductionOrderScreen()),
                 );
-                if (newOrder != null) {
-                  setState(() {
-                    _newlyCreatedOrder = newOrder;
-                    _selectedStatusFilter = 'all';
-                  });
-                }
               },
               tooltip: appLocalizations.createOrder,
             ),
@@ -197,16 +190,10 @@ class _ProductionOrdersListScreenState extends State<ProductionOrdersListScreen>
                           if (isPreparer) const SizedBox(height: 24),
                           if (isPreparer)
                             ElevatedButton.icon(
-                              onPressed: () async {
-                                final newOrder = await Navigator.of(context).push<ProductionOrderModel?>(
+                              onPressed: () {
+                                Navigator.of(context).push(
                                   MaterialPageRoute(builder: (_) => CreateProductionOrderScreen()),
                                 );
-                                if (newOrder != null) {
-                                  setState(() {
-                                    _newlyCreatedOrder = newOrder;
-                                    _selectedStatusFilter = 'all';
-                                  });
-                                }
                               },
                               icon: const Icon(Icons.add),
                               label: Text(appLocalizations.createOrder),
@@ -230,13 +217,6 @@ class _ProductionOrdersListScreenState extends State<ProductionOrdersListScreen>
                     .where((order) => order.salesOrderId == null || order.salesOrderId!.isEmpty)
                     .toList();
 
-                if (_newlyCreatedOrder != null) {
-                  final exists = orders.any((o) => o.id == _newlyCreatedOrder!.id);
-                  if (!exists) {
-                    orders = [ _newlyCreatedOrder!, ...orders ];
-                  }
-                  orders = orders.where((o) => o.id == _newlyCreatedOrder!.id).toList();
-                }
 
                 List<ProductionOrderModel> filteredOrders = isPreparer
                     ? orders.where((order) => order.orderPreparerUid == currentUser.uid).toList()


### PR DESCRIPTION
## Summary
- show only production orders that were manually created
- simplify button behavior after creation

## Testing
- `dart format lib/presentation/production/create_production_order_screen.dart lib/presentation/production/production_orders_list_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864460f57cc832aaa4c2ea4459cbcdf