### PR TITLE
Add spare parts and basic stock tracking

### DIFF
--- a/lib/data/models/inventory_balance_model.dart
+++ b/lib/data/models/inventory_balance_model.dart
@@ -1,0 +1,85 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+enum InventoryItemType { rawMaterial, finishedProduct, sparePart }
+
+InventoryItemType inventoryItemTypeFromString(String type) {
+  switch (type) {
+    case 'raw':
+      return InventoryItemType.rawMaterial;
+    case 'product':
+      return InventoryItemType.finishedProduct;
+    case 'spare':
+      return InventoryItemType.sparePart;
+    default:
+      return InventoryItemType.rawMaterial;
+  }
+}
+
+String inventoryItemTypeToString(InventoryItemType type) {
+  switch (type) {
+    case InventoryItemType.rawMaterial:
+      return 'raw';
+    case InventoryItemType.finishedProduct:
+      return 'product';
+    case InventoryItemType.sparePart:
+      return 'spare';
+  }
+}
+
+class InventoryBalanceModel {
+  final String id;
+  final String itemId;
+  final InventoryItemType type;
+  final double quantity;
+  final double minQuantity;
+  final Timestamp? lastUpdated;
+
+  InventoryBalanceModel({
+    required this.id,
+    required this.itemId,
+    required this.type,
+    required this.quantity,
+    required this.minQuantity,
+    this.lastUpdated,
+  });
+
+  factory InventoryBalanceModel.fromDocumentSnapshot(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return InventoryBalanceModel(
+      id: doc.id,
+      itemId: data['itemId'] ?? '',
+      type: inventoryItemTypeFromString(data['type'] ?? 'raw'),
+      quantity: (data['quantity'] as num?)?.toDouble() ?? 0,
+      minQuantity: (data['minQuantity'] as num?)?.toDouble() ?? 0,
+      lastUpdated: data['lastUpdated'] as Timestamp?,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'itemId': itemId,
+      'type': inventoryItemTypeToString(type),
+      'quantity': quantity,
+      'minQuantity': minQuantity,
+      'lastUpdated': lastUpdated,
+    };
+  }
+
+  InventoryBalanceModel copyWith({
+    String? id,
+    String? itemId,
+    InventoryItemType? type,
+    double? quantity,
+    double? minQuantity,
+    Timestamp? lastUpdated,
+  }) {
+    return InventoryBalanceModel(
+      id: id ?? this.id,
+      itemId: itemId ?? this.itemId,
+      type: type ?? this.type,
+      quantity: quantity ?? this.quantity,
+      minQuantity: minQuantity ?? this.minQuantity,
+      lastUpdated: lastUpdated ?? this.lastUpdated,
+    );
+  }
+}

--- a/lib/data/models/spare_part_model.dart
+++ b/lib/data/models/spare_part_model.dart
@@ -1,0 +1,62 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class SparePartModel {
+  final String id;
+  final String code;
+  final String name;
+  final String unit;
+  final Timestamp? lastUpdated;
+
+  SparePartModel({
+    required this.id,
+    required this.code,
+    required this.name,
+    required this.unit,
+    this.lastUpdated,
+  });
+
+  factory SparePartModel.fromDocumentSnapshot(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return SparePartModel(
+      id: doc.id,
+      code: data['code'] ?? '',
+      name: data['name'] ?? '',
+      unit: data['unit'] ?? '',
+      lastUpdated: data['lastUpdated'] as Timestamp?,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'code': code,
+      'name': name,
+      'unit': unit,
+      'lastUpdated': lastUpdated,
+    };
+  }
+
+  SparePartModel copyWith({
+    String? id,
+    String? code,
+    String? name,
+    String? unit,
+    Timestamp? lastUpdated,
+  }) {
+    return SparePartModel(
+      id: id ?? this.id,
+      code: code ?? this.code,
+      name: name ?? this.name,
+      unit: unit ?? this.unit,
+      lastUpdated: lastUpdated ?? this.lastUpdated,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is SparePartModel && other.id == id;
+  }
+
+  @override
+  int get hashCode => id.hashCode;
+}

--- a/lib/data/repositories/inventory_repository_impl.dart
+++ b/lib/data/repositories/inventory_repository_impl.dart
@@ -2,6 +2,8 @@ import 'package:plastic_factory_management/data/datasources/inventory_datasource
 import 'package:plastic_factory_management/data/models/raw_material_model.dart';
 import 'package:plastic_factory_management/data/models/product_model.dart';
 import 'package:plastic_factory_management/data/models/template_model.dart';
+import 'package:plastic_factory_management/data/models/spare_part_model.dart';
+import 'package:plastic_factory_management/data/models/inventory_balance_model.dart';
 import 'package:plastic_factory_management/domain/repositories/inventory_repository.dart';
 import 'dart:io';
 import 'dart:typed_data';
@@ -86,5 +88,45 @@ class InventoryRepositoryImpl implements InventoryRepository {
   @override
   Future<void> deleteProduct(String productId) {
     return datasource.deleteProduct(productId);
+  }
+
+  // --- Spare Parts ---
+  @override
+  Stream<List<SparePartModel>> getSpareParts() {
+    return datasource.getSpareParts();
+  }
+
+  @override
+  Future<void> addSparePart(SparePartModel sparePart) {
+    return datasource.addSparePart(sparePart);
+  }
+
+  @override
+  Future<void> updateSparePart(SparePartModel sparePart) {
+    return datasource.updateSparePart(sparePart);
+  }
+
+  @override
+  Future<void> deleteSparePart(String sparePartId) {
+    return datasource.deleteSparePart(sparePartId);
+  }
+
+  // --- Inventory Balances ---
+  @override
+  Stream<List<InventoryBalanceModel>> getInventoryBalances(InventoryItemType type) {
+    return datasource.getInventoryBalances(type);
+  }
+
+  @override
+  Future<void> updateInventoryQuantity({
+    required String itemId,
+    required InventoryItemType type,
+    required double delta,
+  }) {
+    return datasource.updateInventoryQuantity(
+      itemId: itemId,
+      type: type,
+      delta: delta,
+    );
   }
 }

--- a/lib/domain/repositories/inventory_repository.dart
+++ b/lib/domain/repositories/inventory_repository.dart
@@ -3,6 +3,8 @@
 import 'package:plastic_factory_management/data/models/raw_material_model.dart';
 import 'package:plastic_factory_management/data/models/product_model.dart';
 import 'package:plastic_factory_management/data/models/template_model.dart';
+import 'package:plastic_factory_management/data/models/spare_part_model.dart';
+import 'package:plastic_factory_management/data/models/inventory_balance_model.dart';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -26,4 +28,18 @@ abstract class InventoryRepository {
   Future<void> updateProduct(ProductModel product,
       {File? newImageFile, Uint8List? newImageBytes});
   Future<void> deleteProduct(String productId);
+
+  // --- Spare Parts ---
+  Stream<List<SparePartModel>> getSpareParts();
+  Future<void> addSparePart(SparePartModel sparePart);
+  Future<void> updateSparePart(SparePartModel sparePart);
+  Future<void> deleteSparePart(String sparePartId);
+
+  // --- Inventory Balances ---
+  Stream<List<InventoryBalanceModel>> getInventoryBalances(InventoryItemType type);
+  Future<void> updateInventoryQuantity({
+    required String itemId,
+    required InventoryItemType type,
+    required double delta,
+  });
 }

--- a/lib/presentation/inventory/inventory_management_screen.dart
+++ b/lib/presentation/inventory/inventory_management_screen.dart
@@ -26,6 +26,13 @@ class InventoryManagementScreen extends StatelessWidget {
             ),
             const SizedBox(height: 16),
             ElevatedButton.icon(
+              icon: const Icon(Icons.build_circle_outlined),
+              label: const Text('قطع الغيار', textDirection: TextDirection.rtl),
+              onPressed: () =>
+                  Navigator.of(context).pushNamed(AppRouter.sparePartsRoute),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton.icon(
               icon: const Icon(Icons.category),
               label: Text(appLocalizations.productCatalog),
               onPressed: () =>

--- a/lib/presentation/inventory/spare_parts_screen.dart
+++ b/lib/presentation/inventory/spare_parts_screen.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:plastic_factory_management/data/models/spare_part_model.dart';
+import 'package:plastic_factory_management/domain/usecases/inventory_usecases.dart';
+
+class SparePartsScreen extends StatelessWidget {
+  const SparePartsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final useCases = Provider.of<InventoryUseCases>(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('قطع الغيار'),
+      ),
+      body: StreamBuilder<List<SparePartModel>>(
+        stream: useCases.getSpareParts(),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final parts = snapshot.data!;
+          return ListView.builder(
+            itemCount: parts.length,
+            itemBuilder: (context, index) {
+              final part = parts[index];
+              return ListTile(
+                title: Text(part.name),
+                subtitle: Text(part.code),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/presentation/routes/app_router.dart
+++ b/lib/presentation/routes/app_router.dart
@@ -10,6 +10,7 @@ import 'package:plastic_factory_management/presentation/production/production_bo
 import 'package:plastic_factory_management/presentation/inventory/raw_materials_screen.dart';
 import 'package:plastic_factory_management/presentation/inventory/product_catalog_screen.dart'; // يمكن إعادة استخدامها
 import 'package:plastic_factory_management/presentation/inventory/templates_screen.dart';
+import 'package:plastic_factory_management/presentation/inventory/spare_parts_screen.dart';
 import 'package:plastic_factory_management/presentation/machinery/machine_profiles_screen.dart';
 import 'package:plastic_factory_management/presentation/machinery/operator_profiles_screen.dart';
 import 'package:plastic_factory_management/presentation/machinery/mold_installation_tasks_screen.dart';
@@ -40,6 +41,7 @@ class AppRouter {
   static const String rawMaterialsRoute = '/inventory/raw_materials';
   static const String productCatalogRoute = '/inventory/product_catalog';
   static const String templatesRoute = '/inventory/templates';
+  static const String sparePartsRoute = '/inventory/spare_parts';
   static const String machineProfilesRoute = '/machinery/machines';
   static const String operatorProfilesRoute = '/machinery/operators';
   static const String moldInstallationTasksRoute = '/machinery/mold_tasks';
@@ -73,6 +75,8 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => const ProductionBoardScreen());
       case rawMaterialsRoute:
         return MaterialPageRoute(builder: (_) => RawMaterialsScreen());
+      case sparePartsRoute:
+        return MaterialPageRoute(builder: (_) => const SparePartsScreen());
       case productCatalogRoute:
         return MaterialPageRoute(builder: (_) => ProductCatalogScreen());
       case templatesRoute:


### PR DESCRIPTION
## Summary
- introduce `SparePartModel` and `InventoryBalanceModel`
- extend inventory data source and repository with spare parts and quantity functions
- implement new inventory use cases including notification support
- add spare parts screen and routing
- update inventory management menu

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644b616824832aa76a173752edbbd4