### PR TITLE
Add inventory type selection

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -428,4 +428,7 @@
   "reports": "التقارير والتحليلات",
   "procurement": "وحدة المشتريات",
   "documentCenter": "مركز الوثائق والسياسات"
+  "addInventoryEntry": "إضافة حركة مخزون",
+  "selectInventoryType": "اختر نوع المخزون",
+  "selectItem": "اختر الصنف",
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -29,6 +29,9 @@
               "machineRequired": "Machine is required.",
               "enterActualTimeRequired": "Please enter the actual time spent.",
               "approvedBy": "by",
+  "addInventoryEntry": "إضافة حركة مخزون",
+  "selectInventoryType": "اختر نوع المخزون",
+  "selectItem": "اختر الصنف",
               "unknown": "Unknown",
   "loginTitle": "تسجيل الدخول",
   "emailHint": "البريد الإلكتروني",
@@ -434,5 +437,8 @@
   "reports": "Reports & Analytics",
   "procurement": "Procurement Module",
   "documentCenter": "Documents & Policies",
+  "addInventoryEntry": "إضافة حركة مخزون",
+  "selectInventoryType": "اختر نوع المخزون",
+  "selectItem": "اختر الصنف",
   "unknown": "Unknown"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -420,6 +420,9 @@ class AppLocalizations {
   String get reports => _strings["reports"] ?? "reports";
   String get procurement => _strings["procurement"] ?? "procurement";
   String get documentCenter => _strings["documentCenter"] ?? "documentCenter";
+  String get addInventoryEntry => _strings["addInventoryEntry"] ?? "addInventoryEntry";
+  String get selectInventoryType => _strings["selectInventoryType"] ?? "selectInventoryType";
+  String get selectItem => _strings["selectItem"] ?? "selectItem";
 
 
 }

--- a/lib/presentation/inventory/inventory_adjustment_screen.dart
+++ b/lib/presentation/inventory/inventory_adjustment_screen.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:plastic_factory_management/data/models/inventory_balance_model.dart';
+import 'package:plastic_factory_management/data/models/product_model.dart';
+import 'package:plastic_factory_management/data/models/raw_material_model.dart';
+import 'package:plastic_factory_management/data/models/spare_part_model.dart';
+import 'package:plastic_factory_management/domain/usecases/inventory_usecases.dart';
+import 'package:plastic_factory_management/l10n/app_localizations.dart';
+
+class InventoryAdjustmentScreen extends StatefulWidget {
+  const InventoryAdjustmentScreen({Key? key}) : super(key: key);
+
+  @override
+  State<InventoryAdjustmentScreen> createState() => _InventoryAdjustmentScreenState();
+}
+
+class _InventoryAdjustmentScreenState extends State<InventoryAdjustmentScreen> {
+  InventoryItemType? _type;
+  String? _itemId;
+  final TextEditingController _qtyController = TextEditingController();
+
+  @override
+  void dispose() {
+    _qtyController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final appLocalizations = AppLocalizations.of(context)!;
+    final useCases = Provider.of<InventoryUseCases>(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(appLocalizations.addInventoryEntry),
+        centerTitle: true,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            DropdownButtonFormField<InventoryItemType>(
+              decoration: InputDecoration(labelText: appLocalizations.selectInventoryType),
+              value: _type,
+              items: const [
+                DropdownMenuItem(
+                  value: InventoryItemType.rawMaterial,
+                  child: Text('مواد خام', textDirection: TextDirection.rtl),
+                ),
+                DropdownMenuItem(
+                  value: InventoryItemType.finishedProduct,
+                  child: Text('منتج تام', textDirection: TextDirection.rtl),
+                ),
+                DropdownMenuItem(
+                  value: InventoryItemType.sparePart,
+                  child: Text('قطع غيار', textDirection: TextDirection.rtl),
+                ),
+              ],
+              onChanged: (value) => setState(() {
+                _type = value;
+                _itemId = null;
+              }),
+            ),
+            const SizedBox(height: 16),
+            if (_type != null)
+              StreamBuilder<List<dynamic>>(
+                stream: _itemsStream(useCases, _type!),
+                builder: (context, snapshot) {
+                  if (!snapshot.hasData) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+                  return DropdownButtonFormField<String>(
+                    decoration: InputDecoration(labelText: appLocalizations.selectItem),
+                    value: _itemId,
+                    items: snapshot.data!
+                        .map<DropdownMenuItem<String>>(
+                          (e) => DropdownMenuItem(value: _getId(e), child: Text(_getName(e))),
+                        )
+                        .toList(),
+                    onChanged: (value) => setState(() => _itemId = value),
+                  );
+                },
+              ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _qtyController,
+              keyboardType: const TextInputType.numberWithOptions(decimal: true),
+              decoration: InputDecoration(labelText: appLocalizations.quantity),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: _type != null && _itemId != null && _qtyController.text.isNotEmpty
+                  ? () async {
+                      final qty = double.tryParse(_qtyController.text) ?? 0;
+                      await useCases.adjustInventory(itemId: _itemId!, type: _type!, delta: qty);
+                      if (mounted) Navigator.of(context).pop();
+                    }
+                  : null,
+              child: Text(appLocalizations.save),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Stream<List<dynamic>> _itemsStream(InventoryUseCases useCases, InventoryItemType type) {
+    switch (type) {
+      case InventoryItemType.rawMaterial:
+        return useCases.getRawMaterials();
+      case InventoryItemType.finishedProduct:
+        return useCases.getProducts();
+      case InventoryItemType.sparePart:
+        return useCases.getSpareParts();
+    }
+  }
+
+  String _getId(dynamic item) {
+    if (item is RawMaterialModel) return item.id;
+    if (item is ProductModel) return item.id;
+    if (item is SparePartModel) return item.id;
+    return '';
+  }
+
+  String _getName(dynamic item) {
+    if (item is RawMaterialModel) return item.name;
+    if (item is ProductModel) return item.name;
+    if (item is SparePartModel) return item.name;
+    return '';
+  }
+}

--- a/lib/presentation/inventory/inventory_management_screen.dart
+++ b/lib/presentation/inventory/inventory_management_screen.dart
@@ -54,6 +54,13 @@ class InventoryManagementScreen extends StatelessWidget {
             ),
             const SizedBox(height: 16),
             ElevatedButton.icon(
+              icon: const Icon(Icons.add),
+              label: Text(appLocalizations.addInventoryEntry),
+              onPressed: () =>
+                  Navigator.of(context).pushNamed(AppRouter.inventoryAdjustmentRoute),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton.icon(
               icon: const Icon(Icons.inventory_2_outlined),
               label: const Text('استلام المنتجات الجاهزة', textDirection: TextDirection.rtl),
               onPressed: () {},

--- a/lib/presentation/routes/app_router.dart
+++ b/lib/presentation/routes/app_router.dart
@@ -20,6 +20,7 @@ import 'package:plastic_factory_management/presentation/sales/create_sales_order
 import 'package:plastic_factory_management/presentation/sales/sales_orders_list_screen.dart'; // استيراد جديد
 import 'package:plastic_factory_management/presentation/quality/quality_inspection_screen.dart';
 import 'package:plastic_factory_management/presentation/inventory/inventory_management_screen.dart';
+import 'package:plastic_factory_management/presentation/inventory/inventory_adjustment_screen.dart';
 import 'package:plastic_factory_management/presentation/inventory/warehouse_requests_screen.dart';
 import 'package:plastic_factory_management/presentation/accounting/accounting_screen.dart';
 import 'package:plastic_factory_management/presentation/notifications/notifications_screen.dart';
@@ -51,6 +52,7 @@ class AppRouter {
   static const String salesOrdersListRoute = '/sales/orders/list'; // مسار جديد
   static const String qualityInspectionRoute = '/quality/inspections';
   static const String inventoryManagementRoute = '/inventory/management';
+  static const String inventoryAdjustmentRoute = '/inventory/adjustment';
   static const String warehouseRequestsRoute = '/inventory/warehouse_requests';
   static const String accountingRoute = '/accounting';
   static const String userManagementRoute = '/management/users';
@@ -99,6 +101,8 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => QualityInspectionScreen());
       case inventoryManagementRoute:
         return MaterialPageRoute(builder: (_) => InventoryManagementScreen());
+      case inventoryAdjustmentRoute:
+        return MaterialPageRoute(builder: (_) => const InventoryAdjustmentScreen());
       case warehouseRequestsRoute:
         return MaterialPageRoute(builder: (_) => WarehouseRequestsScreen());
       case accountingRoute:


### PR DESCRIPTION
## Summary
- allow choosing inventory item type when adjusting inventory
- add Inventory Adjustment screen
- localize inventory adjustment labels
- wire up new screen in router and inventory module

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644f2734e4832ab81bedfcefe42789