### PR TITLE
Implement inventory item addition screen

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -429,6 +429,7 @@
   "procurement": "وحدة المشتريات",
   "documentCenter": "مركز الوثائق والسياسات",
   "addInventoryEntry": "إضافة حركة مخزون",
+  "addInventoryItem": "إضافة صنف مخزون",
   "selectInventoryType": "اختر نوع المخزون",
   "selectItem": "اختر الصنف",
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -438,6 +438,7 @@
   "procurement": "Procurement Module",
   "documentCenter": "Documents & Policies",
   "addInventoryEntry": "إضافة حركة مخزون",
+  "addInventoryItem": "إضافة صنف مخزون",
   "selectInventoryType": "اختر نوع المخزون",
   "selectItem": "اختر الصنف",
   "unknown": "Unknown"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -421,6 +421,7 @@ class AppLocalizations {
   String get procurement => _strings["procurement"] ?? "procurement";
   String get documentCenter => _strings["documentCenter"] ?? "documentCenter";
   String get addInventoryEntry => _strings["addInventoryEntry"] ?? "addInventoryEntry";
+  String get addInventoryItem => _strings["addInventoryItem"] ?? "addInventoryItem";
   String get selectInventoryType => _strings["selectInventoryType"] ?? "selectInventoryType";
   String get selectItem => _strings["selectItem"] ?? "selectItem";
 

--- a/lib/presentation/inventory/inventory_add_item_screen.dart
+++ b/lib/presentation/inventory/inventory_add_item_screen.dart
@@ -1,0 +1,187 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:plastic_factory_management/data/models/inventory_balance_model.dart';
+import 'package:plastic_factory_management/domain/usecases/inventory_usecases.dart';
+import 'package:plastic_factory_management/l10n/app_localizations.dart';
+
+class InventoryAddItemScreen extends StatefulWidget {
+  const InventoryAddItemScreen({Key? key}) : super(key: key);
+
+  @override
+  State<InventoryAddItemScreen> createState() => _InventoryAddItemScreenState();
+}
+
+class _InventoryAddItemScreenState extends State<InventoryAddItemScreen> {
+  InventoryItemType? _type;
+  final TextEditingController _codeController = TextEditingController();
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _unitController = TextEditingController();
+  final TextEditingController _packagingController = TextEditingController();
+
+  @override
+  void dispose() {
+    _codeController.dispose();
+    _nameController.dispose();
+    _unitController.dispose();
+    _packagingController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final appLocalizations = AppLocalizations.of(context)!;
+    final useCases = Provider.of<InventoryUseCases>(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(appLocalizations.addInventoryItem),
+        centerTitle: true,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              DropdownButtonFormField<InventoryItemType>(
+                decoration: InputDecoration(labelText: appLocalizations.selectInventoryType),
+                value: _type,
+                items: const [
+                  DropdownMenuItem(
+                    value: InventoryItemType.rawMaterial,
+                    child: Text('مواد خام', textDirection: TextDirection.rtl),
+                  ),
+                  DropdownMenuItem(
+                    value: InventoryItemType.finishedProduct,
+                    child: Text('منتج تام', textDirection: TextDirection.rtl),
+                  ),
+                  DropdownMenuItem(
+                    value: InventoryItemType.sparePart,
+                    child: Text('قطع غيار', textDirection: TextDirection.rtl),
+                  ),
+                ],
+                onChanged: (value) => setState(() {
+                  _type = value;
+                  _codeController.clear();
+                  _nameController.clear();
+                  _unitController.clear();
+                  _packagingController.clear();
+                }),
+              ),
+              const SizedBox(height: 16),
+              if (_type != null) ..._buildFields(appLocalizations),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: _canSubmit()
+                    ? () async {
+                        switch (_type) {
+                          case InventoryItemType.rawMaterial:
+                            await useCases.addRawMaterial(
+                              code: _codeController.text,
+                              name: _nameController.text,
+                              unit: _unitController.text,
+                            );
+                            break;
+                          case InventoryItemType.finishedProduct:
+                            await useCases.addProduct(
+                              productCode: _codeController.text,
+                              name: _nameController.text,
+                              description: null,
+                              billOfMaterials: const [],
+                              colors: const [],
+                              additives: const [],
+                              packagingType: _packagingController.text,
+                              requiresPackaging: false,
+                              requiresSticker: false,
+                              productType: 'single',
+                              expectedProductionTimePerUnit: 0,
+                            );
+                            break;
+                          case InventoryItemType.sparePart:
+                            await useCases.addSparePart(
+                              code: _codeController.text,
+                              name: _nameController.text,
+                              unit: _unitController.text,
+                            );
+                            break;
+                          default:
+                            return;
+                        }
+                        if (mounted) Navigator.of(context).pop();
+                      }
+                    : null,
+                child: Text(appLocalizations.add),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  bool _canSubmit() {
+    if (_type == null) return false;
+    if (_codeController.text.isEmpty || _nameController.text.isEmpty) return false;
+    if (_type == InventoryItemType.finishedProduct) {
+      return true;
+    }
+    return _unitController.text.isNotEmpty;
+  }
+
+  List<Widget> _buildFields(AppLocalizations loc) {
+    switch (_type) {
+      case InventoryItemType.rawMaterial:
+        return [
+          TextFormField(
+            controller: _nameController,
+            decoration: InputDecoration(labelText: loc.materialName),
+          ),
+          const SizedBox(height: 12),
+          TextFormField(
+            controller: _codeController,
+            decoration: InputDecoration(labelText: loc.materialCode),
+          ),
+          const SizedBox(height: 12),
+          TextFormField(
+            controller: _unitController,
+            decoration: InputDecoration(labelText: loc.unitOfMeasurement),
+          ),
+        ];
+      case InventoryItemType.finishedProduct:
+        return [
+          TextFormField(
+            controller: _nameController,
+            decoration: InputDecoration(labelText: loc.productName),
+          ),
+          const SizedBox(height: 12),
+          TextFormField(
+            controller: _codeController,
+            decoration: InputDecoration(labelText: loc.productCode),
+          ),
+          const SizedBox(height: 12),
+          TextFormField(
+            controller: _packagingController,
+            decoration: InputDecoration(labelText: loc.packagingType),
+          ),
+        ];
+      case InventoryItemType.sparePart:
+        return [
+          TextFormField(
+            controller: _nameController,
+            decoration: InputDecoration(labelText: loc.materialName),
+          ),
+          const SizedBox(height: 12),
+          TextFormField(
+            controller: _codeController,
+            decoration: InputDecoration(labelText: loc.materialCode),
+          ),
+          const SizedBox(height: 12),
+          TextFormField(
+            controller: _unitController,
+            decoration: InputDecoration(labelText: loc.unitOfMeasurement),
+          ),
+        ];
+      default:
+        return [];
+    }
+  }
+}

--- a/lib/presentation/inventory/inventory_management_screen.dart
+++ b/lib/presentation/inventory/inventory_management_screen.dart
@@ -54,6 +54,13 @@ class InventoryManagementScreen extends StatelessWidget {
             ),
             const SizedBox(height: 16),
             ElevatedButton.icon(
+              icon: const Icon(Icons.add_circle_outline),
+              label: Text(appLocalizations.addInventoryItem),
+              onPressed: () =>
+                  Navigator.of(context).pushNamed(AppRouter.inventoryAddItemRoute),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton.icon(
               icon: const Icon(Icons.add),
               label: Text(appLocalizations.addInventoryEntry),
               onPressed: () =>

--- a/lib/presentation/routes/app_router.dart
+++ b/lib/presentation/routes/app_router.dart
@@ -21,6 +21,7 @@ import 'package:plastic_factory_management/presentation/sales/sales_orders_list_
 import 'package:plastic_factory_management/presentation/quality/quality_inspection_screen.dart';
 import 'package:plastic_factory_management/presentation/inventory/inventory_management_screen.dart';
 import 'package:plastic_factory_management/presentation/inventory/inventory_adjustment_screen.dart';
+import 'package:plastic_factory_management/presentation/inventory/inventory_add_item_screen.dart';
 import 'package:plastic_factory_management/presentation/inventory/warehouse_requests_screen.dart';
 import 'package:plastic_factory_management/presentation/accounting/accounting_screen.dart';
 import 'package:plastic_factory_management/presentation/notifications/notifications_screen.dart';
@@ -53,6 +54,7 @@ class AppRouter {
   static const String qualityInspectionRoute = '/quality/inspections';
   static const String inventoryManagementRoute = '/inventory/management';
   static const String inventoryAdjustmentRoute = '/inventory/adjustment';
+  static const String inventoryAddItemRoute = '/inventory/add_item';
   static const String warehouseRequestsRoute = '/inventory/warehouse_requests';
   static const String accountingRoute = '/accounting';
   static const String userManagementRoute = '/management/users';
@@ -103,6 +105,8 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => InventoryManagementScreen());
       case inventoryAdjustmentRoute:
         return MaterialPageRoute(builder: (_) => const InventoryAdjustmentScreen());
+      case inventoryAddItemRoute:
+        return MaterialPageRoute(builder: (_) => const InventoryAddItemScreen());
       case warehouseRequestsRoute:
         return MaterialPageRoute(builder: (_) => WarehouseRequestsScreen());
       case accountingRoute:


### PR DESCRIPTION
## Summary
- add InventoryAddItemScreen with type selection for raw materials, products, or spare parts
- wire new screen through AppRouter and InventoryManagementScreen
- localize new string `addInventoryItem`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686452e63ea4832a8d7f8c5937907de8