### PR TITLE
Implement accounting module pages

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -445,4 +445,16 @@
   "paymentsManagement": "إدارة الدفعات",
   "purchasesManagement": "إدارة المشتريات",
   "sparePartRequests": "طلبات قطع الغيار",
+  "recordPayment": "تسجيل دفعة",
+  "addPurchase": "إضافة شراء",
+  "selectCustomer": "اختر العميل",
+  "amount": "المبلغ",
+  "method": "طريقة الدفع",
+  "paymentDate": "تاريخ الدفع",
+  "category": "التصنيف",
+  "linkedMaintenanceLog": "سجل الصيانة المرتبط",
+  "linkedProductionOrder": "أمر الإنتاج المرتبط",
+  "sparePartRequestDetails": "تفاصيل طلب قطع الغيار",
+  "rejectRequest": "رفض الطلب",
+  "reason": "السبب"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -454,5 +454,17 @@
   "paymentsManagement": "Payments",
   "purchasesManagement": "Purchases",
   "sparePartRequests": "Spare Part Requests",
+  "recordPayment": "Record Payment",
+  "addPurchase": "Add Purchase",
+  "selectCustomer": "Select Customer",
+  "amount": "Amount",
+  "method": "Payment Method",
+  "paymentDate": "Payment Date",
+  "category": "Category",
+  "linkedMaintenanceLog": "Linked Maintenance Log",
+  "linkedProductionOrder": "Linked Production Order",
+  "sparePartRequestDetails": "Request Details",
+  "rejectRequest": "Reject Request",
+  "reason": "Reason",
   "unknown": "Unknown"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -437,6 +437,18 @@ class AppLocalizations {
   String get paymentsManagement => _strings["paymentsManagement"] ?? "paymentsManagement";
   String get purchasesManagement => _strings["purchasesManagement"] ?? "purchasesManagement";
   String get sparePartRequests => _strings["sparePartRequests"] ?? "sparePartRequests";
+  String get recordPayment => _strings["recordPayment"] ?? "recordPayment";
+  String get addPurchase => _strings["addPurchase"] ?? "addPurchase";
+  String get selectCustomer => _strings["selectCustomer"] ?? "selectCustomer";
+  String get amount => _strings["amount"] ?? "amount";
+  String get method => _strings["method"] ?? "method";
+  String get paymentDate => _strings["paymentDate"] ?? "paymentDate";
+  String get category => _strings["category"] ?? "category";
+  String get linkedMaintenanceLog => _strings["linkedMaintenanceLog"] ?? "linkedMaintenanceLog";
+  String get linkedProductionOrder => _strings["linkedProductionOrder"] ?? "linkedProductionOrder";
+  String get sparePartRequestDetails => _strings["sparePartRequestDetails"] ?? "sparePartRequestDetails";
+  String get rejectRequest => _strings["rejectRequest"] ?? "rejectRequest";
+  String get reason => _strings["reason"] ?? "reason";
 
 
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,6 +41,9 @@ import 'package:plastic_factory_management/domain/usecases/maintenance_usecases.
 import 'package:plastic_factory_management/data/datasources/sales_datasource.dart'; // استيراد جديد
 import 'package:plastic_factory_management/data/repositories/sales_repository_impl.dart'; // استيراد جديد
 import 'package:plastic_factory_management/domain/usecases/sales_usecases.dart'; // استيراد جديد
+import 'package:plastic_factory_management/data/datasources/financial_datasource.dart';
+import 'package:plastic_factory_management/data/repositories/financial_repository_impl.dart';
+import 'package:plastic_factory_management/domain/usecases/financial_usecases.dart';
 // استيرادات Notifications
 import 'package:plastic_factory_management/data/datasources/notification_datasource.dart';
 import 'package:plastic_factory_management/data/repositories/notification_repository_impl.dart';
@@ -196,6 +199,21 @@ class MyApp extends StatelessWidget {
             Provider.of<SalesRepositoryImpl>(context, listen: false),
             Provider.of<NotificationUseCases>(context, listen: false),
             Provider.of<UserUseCases>(context, listen: false),
+          ),
+        ),
+        // Financial dependencies
+        Provider<FinancialDatasource>(
+          create: (_) => FinancialDatasource(),
+        ),
+        Provider<FinancialRepositoryImpl>(
+          create: (context) => FinancialRepositoryImpl(
+            Provider.of<FinancialDatasource>(context, listen: false),
+          ),
+        ),
+        Provider<FinancialUseCases>(
+          create: (context) => FinancialUseCases(
+            Provider.of<FinancialRepositoryImpl>(context, listen: false),
+            Provider.of<SalesRepositoryImpl>(context, listen: false),
           ),
         ),
       ],

--- a/lib/presentation/accounting/accounting_screen.dart
+++ b/lib/presentation/accounting/accounting_screen.dart
@@ -35,7 +35,8 @@ class AccountingScreen extends StatelessWidget {
             ElevatedButton.icon(
               icon: const Icon(Icons.check_circle_outline),
               label: Text(appLocalizations.sparePartRequests),
-              onPressed: () {},
+              onPressed: () => Navigator.of(context)
+                  .pushNamed(AppRouter.sparePartRequestsRoute),
             ),
             const SizedBox(height: 16),
             ElevatedButton.icon(
@@ -47,13 +48,15 @@ class AccountingScreen extends StatelessWidget {
             ElevatedButton.icon(
               icon: const Icon(Icons.payments_outlined),
               label: Text(appLocalizations.paymentsManagement),
-              onPressed: () {},
+              onPressed: () =>
+                  Navigator.of(context).pushNamed(AppRouter.paymentsRoute),
             ),
             const SizedBox(height: 16),
             ElevatedButton.icon(
               icon: const Icon(Icons.shopping_cart_checkout),
               label: Text(appLocalizations.purchasesManagement),
-              onPressed: () {},
+              onPressed: () =>
+                  Navigator.of(context).pushNamed(AppRouter.purchasesRoute),
             ),
           ],
         ),

--- a/lib/presentation/accounting/payments_screen.dart
+++ b/lib/presentation/accounting/payments_screen.dart
@@ -1,0 +1,194 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:intl/intl.dart' as intl;
+import 'package:plastic_factory_management/l10n/app_localizations.dart';
+import 'package:plastic_factory_management/data/models/customer_model.dart';
+import 'package:plastic_factory_management/data/models/payment_model.dart';
+import 'package:plastic_factory_management/data/models/user_model.dart';
+import 'package:plastic_factory_management/domain/usecases/financial_usecases.dart';
+import 'package:plastic_factory_management/domain/usecases/sales_usecases.dart';
+
+class PaymentsScreen extends StatefulWidget {
+  const PaymentsScreen({super.key});
+
+  @override
+  State<PaymentsScreen> createState() => _PaymentsScreenState();
+}
+
+class _PaymentsScreenState extends State<PaymentsScreen> {
+  CustomerModel? _selectedCustomer;
+
+  @override
+  Widget build(BuildContext context) {
+    final appLocalizations = AppLocalizations.of(context)!;
+    final financialUseCases = Provider.of<FinancialUseCases>(context);
+    final salesUseCases = Provider.of<SalesUseCases>(context);
+    final currentUser = Provider.of<UserModel?>(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(appLocalizations.paymentsManagement),
+      ),
+      floatingActionButton: _selectedCustomer != null && currentUser != null
+          ? FloatingActionButton(
+              onPressed: () => _showAddPaymentDialog(
+                  context, financialUseCases, currentUser, _selectedCustomer!, appLocalizations),
+              child: const Icon(Icons.add),
+            )
+          : null,
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            StreamBuilder<List<CustomerModel>>(
+              stream: salesUseCases.getCustomers(),
+              builder: (context, snapshot) {
+                if (!snapshot.hasData) {
+                  return const SizedBox.shrink();
+                }
+                final customers = snapshot.data!;
+                return DropdownButton<CustomerModel>(
+                  hint: Text(appLocalizations.selectCustomer),
+                  value: _selectedCustomer,
+                  isExpanded: true,
+                  onChanged: (c) => setState(() => _selectedCustomer = c),
+                  items: customers
+                      .map((c) => DropdownMenuItem(
+                            value: c,
+                            child: Text(c.name, textDirection: TextDirection.rtl),
+                          ))
+                      .toList(),
+                );
+              },
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: _selectedCustomer == null
+                  ? Center(child: Text(appLocalizations.selectCustomer))
+                  : StreamBuilder<List<PaymentModel>>(
+                      stream: financialUseCases
+                          .getPaymentsForCustomer(_selectedCustomer!.id),
+                      builder: (context, snapshot) {
+                        if (snapshot.connectionState == ConnectionState.waiting) {
+                          return const Center(child: CircularProgressIndicator());
+                        }
+                        final payments = snapshot.data ?? [];
+                        if (payments.isEmpty) {
+                          return Center(child: Text(appLocalizations.noData));
+                        }
+                        return ListView.builder(
+                          itemCount: payments.length,
+                          itemBuilder: (context, index) {
+                            final p = payments[index];
+                            return ListTile(
+                              title: Text(intl.DateFormat.yMd().format(p.paymentDate.toDate()),
+                                  textDirection: TextDirection.rtl),
+                              subtitle: Text('${p.amount} - ${p.method}',
+                                  textDirection: TextDirection.rtl),
+                            );
+                          },
+                        );
+                      },
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showAddPaymentDialog(
+      BuildContext context,
+      FinancialUseCases useCases,
+      UserModel currentUser,
+      CustomerModel customer,
+      AppLocalizations appLocalizations) {
+    final _formKey = GlobalKey<FormState>();
+    final amountController = TextEditingController();
+    final methodController = TextEditingController(text: 'cash');
+    final notesController = TextEditingController();
+    DateTime selectedDate = DateTime.now();
+
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(appLocalizations.recordPayment, textAlign: TextAlign.center),
+          content: Form(
+            key: _formKey,
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextFormField(
+                    controller: amountController,
+                    keyboardType: TextInputType.number,
+                    decoration: InputDecoration(labelText: appLocalizations.amount),
+                    validator: (v) => v == null || v.isEmpty ? appLocalizations.fieldRequired : null,
+                    textDirection: TextDirection.rtl,
+                  ),
+                  const SizedBox(height: 8),
+                  TextFormField(
+                    controller: methodController,
+                    decoration: InputDecoration(labelText: appLocalizations.method),
+                    textDirection: TextDirection.rtl,
+                  ),
+                  const SizedBox(height: 8),
+                  TextButton.icon(
+                    icon: const Icon(Icons.calendar_today),
+                    label: Text(intl.DateFormat.yMd().format(selectedDate)),
+                    onPressed: () async {
+                      final picked = await showDatePicker(
+                        context: context,
+                        initialDate: selectedDate,
+                        firstDate: DateTime(2000),
+                        lastDate: DateTime.now(),
+                      );
+                      if (picked != null) {
+                        setState(() {
+                          selectedDate = picked;
+                        });
+                      }
+                    },
+                  ),
+                  const SizedBox(height: 8),
+                  TextFormField(
+                    controller: notesController,
+                    decoration: InputDecoration(labelText: appLocalizations.notes),
+                    textDirection: TextDirection.rtl,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: Text(appLocalizations.cancel),
+            ),
+            ElevatedButton(
+              onPressed: () async {
+                if (_formKey.currentState!.validate()) {
+                  final payment = PaymentModel(
+                    id: '',
+                    customerId: customer.id,
+                    customerName: customer.name,
+                    amount: double.tryParse(amountController.text) ?? 0.0,
+                    paymentDate: Timestamp.fromDate(selectedDate),
+                    method: methodController.text,
+                    notes: notesController.text,
+                    recordedByUid: currentUser.uid,
+                    recordedByName: currentUser.name,
+                  );
+                  await useCases.recordPayment(payment: payment, customer: customer);
+                  Navigator.pop(context);
+                }
+              },
+              child: Text(appLocalizations.save),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/presentation/accounting/purchases_screen.dart
+++ b/lib/presentation/accounting/purchases_screen.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:intl/intl.dart' as intl;
+import 'package:plastic_factory_management/l10n/app_localizations.dart';
+import 'package:plastic_factory_management/data/models/purchase_model.dart';
+import 'package:plastic_factory_management/data/models/user_model.dart';
+import 'package:plastic_factory_management/domain/usecases/financial_usecases.dart';
+
+class PurchasesScreen extends StatelessWidget {
+  const PurchasesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final appLocalizations = AppLocalizations.of(context)!;
+    final financialUseCases = Provider.of<FinancialUseCases>(context);
+    final currentUser = Provider.of<UserModel?>(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(appLocalizations.purchasesManagement),
+      ),
+      floatingActionButton: currentUser != null
+          ? FloatingActionButton(
+              onPressed: () =>
+                  _showAddPurchaseDialog(context, financialUseCases, currentUser, appLocalizations),
+              child: const Icon(Icons.add),
+            )
+          : null,
+      body: StreamBuilder<List<PurchaseModel>>(
+        stream: financialUseCases.getPurchases(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final purchases = snapshot.data ?? [];
+          if (purchases.isEmpty) {
+            return Center(child: Text(appLocalizations.noData));
+          }
+          return ListView.builder(
+            itemCount: purchases.length,
+            itemBuilder: (context, index) {
+              final p = purchases[index];
+              return ListTile(
+                title: Text(p.description, textDirection: TextDirection.rtl),
+                subtitle: Text(
+                  '${intl.DateFormat.yMd().format(p.purchaseDate.toDate())} - ${p.amount}',
+                  textDirection: TextDirection.rtl,
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  void _showAddPurchaseDialog(BuildContext context, FinancialUseCases useCases,
+      UserModel currentUser, AppLocalizations appLocalizations) {
+    final _formKey = GlobalKey<FormState>();
+    final descController = TextEditingController();
+    final categoryController = TextEditingController();
+    final amountController = TextEditingController();
+    final maintenanceController = TextEditingController();
+    final productionController = TextEditingController();
+    DateTime selectedDate = DateTime.now();
+
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(appLocalizations.addPurchase, textAlign: TextAlign.center),
+          content: Form(
+            key: _formKey,
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextFormField(
+                    controller: descController,
+                    decoration: InputDecoration(labelText: appLocalizations.description),
+                    validator: (v) => v == null || v.isEmpty ? appLocalizations.fieldRequired : null,
+                    textDirection: TextDirection.rtl,
+                  ),
+                  const SizedBox(height: 8),
+                  TextFormField(
+                    controller: categoryController,
+                    decoration: InputDecoration(labelText: appLocalizations.category),
+                    textDirection: TextDirection.rtl,
+                  ),
+                  const SizedBox(height: 8),
+                  TextFormField(
+                    controller: amountController,
+                    keyboardType: TextInputType.number,
+                    decoration: InputDecoration(labelText: appLocalizations.amount),
+                    validator: (v) => v == null || v.isEmpty ? appLocalizations.fieldRequired : null,
+                    textDirection: TextDirection.rtl,
+                  ),
+                  const SizedBox(height: 8),
+                  TextButton.icon(
+                    icon: const Icon(Icons.calendar_today),
+                    label: Text(intl.DateFormat.yMd().format(selectedDate)),
+                    onPressed: () async {
+                      final picked = await showDatePicker(
+                        context: context,
+                        initialDate: selectedDate,
+                        firstDate: DateTime(2000),
+                        lastDate: DateTime.now(),
+                      );
+                      if (picked != null) {
+                        selectedDate = picked;
+                      }
+                    },
+                  ),
+                  const SizedBox(height: 8),
+                  TextFormField(
+                    controller: maintenanceController,
+                    decoration:
+                        InputDecoration(labelText: appLocalizations.linkedMaintenanceLog),
+                    textDirection: TextDirection.rtl,
+                  ),
+                  const SizedBox(height: 8),
+                  TextFormField(
+                    controller: productionController,
+                    decoration:
+                        InputDecoration(labelText: appLocalizations.linkedProductionOrder),
+                    textDirection: TextDirection.rtl,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: Text(appLocalizations.cancel),
+            ),
+            ElevatedButton(
+              onPressed: () async {
+                if (_formKey.currentState!.validate()) {
+                  final purchase = PurchaseModel(
+                    id: '',
+                    description: descController.text,
+                    category: categoryController.text,
+                    amount: double.tryParse(amountController.text) ?? 0.0,
+                    purchaseDate: Timestamp.fromDate(selectedDate),
+                    maintenanceLogId: maintenanceController.text.isEmpty ? null : maintenanceController.text,
+                    productionOrderId: productionController.text.isEmpty ? null : productionController.text,
+                    createdByUid: currentUser.uid,
+                    createdByName: currentUser.name,
+                  );
+                  await useCases.recordPurchase(purchase);
+                  Navigator.pop(context);
+                }
+              },
+              child: Text(appLocalizations.save),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/presentation/accounting/spare_part_requests_screen.dart
+++ b/lib/presentation/accounting/spare_part_requests_screen.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:intl/intl.dart' as intl;
+import 'package:plastic_factory_management/l10n/app_localizations.dart';
+import 'package:plastic_factory_management/data/models/spare_part_request_model.dart';
+import 'package:plastic_factory_management/data/models/user_model.dart';
+import 'package:plastic_factory_management/domain/usecases/financial_usecases.dart';
+
+class SparePartRequestsScreen extends StatelessWidget {
+  const SparePartRequestsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final appLocalizations = AppLocalizations.of(context)!;
+    final financialUseCases = Provider.of<FinancialUseCases>(context);
+    final currentUser = Provider.of<UserModel?>(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(appLocalizations.sparePartRequests),
+      ),
+      body: StreamBuilder<List<SparePartRequestModel>>(
+        stream: financialUseCases.getSparePartRequests(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final requests = snapshot.data ?? [];
+          if (requests.isEmpty) {
+            return Center(child: Text(appLocalizations.noData));
+          }
+          return ListView.builder(
+            itemCount: requests.length,
+            itemBuilder: (context, index) {
+              final r = requests[index];
+              return Card(
+                margin: const EdgeInsets.all(8),
+                child: ListTile(
+                  title: Text(
+                    '${r.requesterName} - ${intl.DateFormat.yMd().format(r.createdAt.toDate())}',
+                    textDirection: TextDirection.rtl,
+                  ),
+                  subtitle: Text(r.status.name, textDirection: TextDirection.rtl),
+                  onTap: () => _showRequestDialog(context, r, financialUseCases, currentUser, appLocalizations),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  void _showRequestDialog(
+      BuildContext context,
+      SparePartRequestModel request,
+      FinancialUseCases useCases,
+      UserModel? currentUser,
+      AppLocalizations appLocalizations) {
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(appLocalizations.sparePartRequestDetails, textAlign: TextAlign.center),
+          content: SizedBox(
+            width: double.maxFinite,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                ...request.items.map((e) => Text('${e.partName} x${e.quantity}', textDirection: TextDirection.rtl)),
+                const SizedBox(height: 8),
+                Text('${appLocalizations.totalAmount}: ${request.totalAmount}', textDirection: TextDirection.rtl),
+                const SizedBox(height: 8),
+                Text(appLocalizations.statusColon + request.status.name,
+                    textDirection: TextDirection.rtl),
+                if (request.rejectionReason != null)
+                  Text('${appLocalizations.rejectionReason}: ${request.rejectionReason}', textDirection: TextDirection.rtl),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: Text(appLocalizations.cancel),
+            ),
+            if (currentUser != null && request.status == SparePartRequestStatus.pendingApproval)
+              TextButton(
+                onPressed: () async {
+                  await useCases.approveSparePartRequest(request, currentUser.uid, currentUser.name);
+                  Navigator.pop(context);
+                },
+                child: Text(appLocalizations.approve),
+              ),
+            if (currentUser != null && request.status == SparePartRequestStatus.pendingApproval)
+              TextButton(
+                onPressed: () async {
+                  final reasonController = TextEditingController();
+                  final ok = await showDialog<bool>(
+                    context: context,
+                    builder: (context) => AlertDialog(
+                      title: Text(appLocalizations.rejectRequest, textAlign: TextAlign.center),
+                      content: TextField(
+                        controller: reasonController,
+                        decoration: InputDecoration(labelText: appLocalizations.reason),
+                        textDirection: TextDirection.rtl,
+                      ),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.pop(context, false),
+                          child: Text(appLocalizations.cancel),
+                        ),
+                        ElevatedButton(
+                          onPressed: () => Navigator.pop(context, true),
+                          child: Text(appLocalizations.reject),
+                        ),
+                      ],
+                    ),
+                  );
+                  if (ok == true) {
+                    await useCases.rejectSparePartRequest(
+                        request, currentUser.uid, currentUser.name, reasonController.text);
+                    Navigator.pop(context);
+                  }
+                },
+                child: Text(appLocalizations.reject),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/presentation/routes/app_router.dart
+++ b/lib/presentation/routes/app_router.dart
@@ -23,6 +23,9 @@ import 'package:plastic_factory_management/presentation/inventory/inventory_adju
 import 'package:plastic_factory_management/presentation/inventory/inventory_add_item_screen.dart';
 import 'package:plastic_factory_management/presentation/inventory/warehouse_requests_screen.dart';
 import 'package:plastic_factory_management/presentation/accounting/accounting_screen.dart';
+import 'package:plastic_factory_management/presentation/accounting/payments_screen.dart';
+import 'package:plastic_factory_management/presentation/accounting/purchases_screen.dart';
+import 'package:plastic_factory_management/presentation/accounting/spare_part_requests_screen.dart';
 import 'package:plastic_factory_management/presentation/notifications/notifications_screen.dart';
 import 'package:plastic_factory_management/presentation/management/user_management_screen.dart';
 import 'package:plastic_factory_management/presentation/management/returns_screen.dart';
@@ -55,6 +58,9 @@ class AppRouter {
   static const String inventoryAddItemRoute = '/inventory/add_item';
   static const String warehouseRequestsRoute = '/inventory/warehouse_requests';
   static const String accountingRoute = '/accounting';
+  static const String paymentsRoute = '/accounting/payments';
+  static const String purchasesRoute = '/accounting/purchases';
+  static const String sparePartRequestsRoute = '/accounting/spare_requests';
   static const String userManagementRoute = '/management/users';
   static const String returnsRoute = '/management/returns';
   static const String deliveryRoute = '/management/delivery';
@@ -107,6 +113,12 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => WarehouseRequestsScreen());
       case accountingRoute:
         return MaterialPageRoute(builder: (_) => AccountingScreen());
+      case paymentsRoute:
+        return MaterialPageRoute(builder: (_) => const PaymentsScreen());
+      case purchasesRoute:
+        return MaterialPageRoute(builder: (_) => const PurchasesScreen());
+      case sparePartRequestsRoute:
+        return MaterialPageRoute(builder: (_) => const SparePartRequestsScreen());
       case userManagementRoute:
         return MaterialPageRoute(builder: (_) => UserManagementScreen());
       case returnsRoute:


### PR DESCRIPTION
## Summary
- create screens for recording payments, purchases and spare part requests
- wire accounting screen to new pages
- register new routes and providers
- extend localization with finance terms

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864f80aabd8832a8f18810fe8522d2c