### PR TITLE
Fix missing statusColon localization

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -390,6 +390,7 @@
               "approvalDate": "تاريخ الاعتماد",
               "signatureColon": "التوقيع:",
               "attachmentsColon": "المرفقات:",
+              "statusColon": "الحالة:",
               "selectStorekeeper": "اختر أمين المخزن",
               "selectMachineForOrder": "اختر الآلة التي سيتم تشغيلها لهذا الطلب:",
               "machineRequired": "الآلة مطلوبة.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -24,6 +24,7 @@
               "approvalDate": "Approval Date",
               "signatureColon": "Signature:",
               "attachmentsColon": "Attachments:",
+              "statusColon": "Status:",
               "selectStorekeeper": "Select Storekeeper",
               "selectMachineForOrder": "Select the machine to operate for this order:",
               "machineRequired": "Machine is required.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -340,6 +340,7 @@ class AppLocalizations {
   String get approvalDate => _strings["approvalDate"] ?? "approvalDate";
   String get signatureColon => _strings["signatureColon"] ?? "signatureColon";
   String get attachmentsColon => _strings["attachmentsColon"] ?? "attachmentsColon";
+  String get statusColon => _strings["statusColon"] ?? "statusColon";
   String get selectStorekeeper => _strings["selectStorekeeper"] ?? "selectStorekeeper";
   String get selectMachineForOrder => _strings["selectMachineForOrder"] ?? "selectMachineForOrder";
   String get machineRequired => _strings["machineRequired"] ?? "machineRequired";


### PR DESCRIPTION
## Summary
- add `statusColon` entries to English and Arabic ARB files
- expose `statusColon` getter in `AppLocalizations`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864fad43fa8832a8e2064e0d5e17962