### PR TITLE
Add quality control features

### DIFF
--- a/lib/data/datasources/quality_datasource.dart
+++ b/lib/data/datasources/quality_datasource.dart
@@ -1,0 +1,22 @@
+// plastic_factory_management/lib/data/datasources/quality_datasource.dart
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/quality_check_model.dart';
+
+class QualityDatasource {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+
+  Stream<List<QualityCheckModel>> getQualityChecks() {
+    return _firestore
+        .collection('quality_checks')
+        .orderBy('createdAt', descending: true)
+        .snapshots()
+        .map((snapshot) => snapshot.docs
+            .map((doc) => QualityCheckModel.fromDocumentSnapshot(doc))
+            .toList());
+  }
+
+  Future<void> addQualityCheck(QualityCheckModel check) async {
+    await _firestore.collection('quality_checks').add(check.toMap());
+  }
+}

--- a/lib/data/models/quality_check_model.dart
+++ b/lib/data/models/quality_check_model.dart
@@ -1,0 +1,103 @@
+// plastic_factory_management/lib/data/models/quality_check_model.dart
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class QualityCheckModel {
+  final String id;
+  final String productId;
+  final String productName;
+  final int inspectedQuantity;
+  final int rejectedQuantity;
+  final int acceptedQuantity;
+  final String shiftSupervisorUid;
+  final String shiftSupervisorName;
+  final String qualityInspectorUid;
+  final String qualityInspectorName;
+  final String? defectAnalysis;
+  final List<String> imageUrls;
+  final Timestamp createdAt;
+
+  QualityCheckModel({
+    required this.id,
+    required this.productId,
+    required this.productName,
+    required this.inspectedQuantity,
+    required this.rejectedQuantity,
+    required this.acceptedQuantity,
+    required this.shiftSupervisorUid,
+    required this.shiftSupervisorName,
+    required this.qualityInspectorUid,
+    required this.qualityInspectorName,
+    this.defectAnalysis,
+    this.imageUrls = const [],
+    required this.createdAt,
+  });
+
+  factory QualityCheckModel.fromDocumentSnapshot(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return QualityCheckModel(
+      id: doc.id,
+      productId: data['productId'] ?? '',
+      productName: data['productName'] ?? '',
+      inspectedQuantity: data['inspectedQuantity'] ?? 0,
+      rejectedQuantity: data['rejectedQuantity'] ?? 0,
+      acceptedQuantity: data['acceptedQuantity'] ?? 0,
+      shiftSupervisorUid: data['shiftSupervisorUid'] ?? '',
+      shiftSupervisorName: data['shiftSupervisorName'] ?? '',
+      qualityInspectorUid: data['qualityInspectorUid'] ?? '',
+      qualityInspectorName: data['qualityInspectorName'] ?? '',
+      defectAnalysis: data['defectAnalysis'],
+      imageUrls: List<String>.from(data['imageUrls'] ?? []),
+      createdAt: data['createdAt'] ?? Timestamp.now(),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'productId': productId,
+      'productName': productName,
+      'inspectedQuantity': inspectedQuantity,
+      'rejectedQuantity': rejectedQuantity,
+      'acceptedQuantity': acceptedQuantity,
+      'shiftSupervisorUid': shiftSupervisorUid,
+      'shiftSupervisorName': shiftSupervisorName,
+      'qualityInspectorUid': qualityInspectorUid,
+      'qualityInspectorName': qualityInspectorName,
+      'defectAnalysis': defectAnalysis,
+      'imageUrls': imageUrls,
+      'createdAt': createdAt,
+    };
+  }
+
+  QualityCheckModel copyWith({
+    String? id,
+    String? productId,
+    String? productName,
+    int? inspectedQuantity,
+    int? rejectedQuantity,
+    int? acceptedQuantity,
+    String? shiftSupervisorUid,
+    String? shiftSupervisorName,
+    String? qualityInspectorUid,
+    String? qualityInspectorName,
+    String? defectAnalysis,
+    List<String>? imageUrls,
+    Timestamp? createdAt,
+  }) {
+    return QualityCheckModel(
+      id: id ?? this.id,
+      productId: productId ?? this.productId,
+      productName: productName ?? this.productName,
+      inspectedQuantity: inspectedQuantity ?? this.inspectedQuantity,
+      rejectedQuantity: rejectedQuantity ?? this.rejectedQuantity,
+      acceptedQuantity: acceptedQuantity ?? this.acceptedQuantity,
+      shiftSupervisorUid: shiftSupervisorUid ?? this.shiftSupervisorUid,
+      shiftSupervisorName: shiftSupervisorName ?? this.shiftSupervisorName,
+      qualityInspectorUid: qualityInspectorUid ?? this.qualityInspectorUid,
+      qualityInspectorName: qualityInspectorName ?? this.qualityInspectorName,
+      defectAnalysis: defectAnalysis ?? this.defectAnalysis,
+      imageUrls: imageUrls ?? this.imageUrls,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+}

--- a/lib/data/repositories/quality_repository_impl.dart
+++ b/lib/data/repositories/quality_repository_impl.dart
@@ -1,0 +1,20 @@
+// plastic_factory_management/lib/data/repositories/quality_repository_impl.dart
+
+import 'package:plastic_factory_management/data/datasources/quality_datasource.dart';
+import 'package:plastic_factory_management/data/models/quality_check_model.dart';
+import 'package:plastic_factory_management/domain/repositories/quality_repository.dart';
+
+class QualityRepositoryImpl implements QualityRepository {
+  final QualityDatasource datasource;
+  QualityRepositoryImpl(this.datasource);
+
+  @override
+  Stream<List<QualityCheckModel>> getQualityChecks() {
+    return datasource.getQualityChecks();
+  }
+
+  @override
+  Future<void> addQualityCheck(QualityCheckModel check) {
+    return datasource.addQualityCheck(check);
+  }
+}

--- a/lib/domain/repositories/quality_repository.dart
+++ b/lib/domain/repositories/quality_repository.dart
@@ -1,0 +1,8 @@
+// plastic_factory_management/lib/domain/repositories/quality_repository.dart
+
+import 'package:plastic_factory_management/data/models/quality_check_model.dart';
+
+abstract class QualityRepository {
+  Stream<List<QualityCheckModel>> getQualityChecks();
+  Future<void> addQualityCheck(QualityCheckModel check);
+}

--- a/lib/domain/usecases/quality_usecases.dart
+++ b/lib/domain/usecases/quality_usecases.dart
@@ -1,0 +1,44 @@
+// plastic_factory_management/lib/domain/usecases/quality_usecases.dart
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:plastic_factory_management/data/models/quality_check_model.dart';
+import 'package:plastic_factory_management/domain/repositories/quality_repository.dart';
+
+class QualityUseCases {
+  final QualityRepository repository;
+  QualityUseCases(this.repository);
+
+  Stream<List<QualityCheckModel>> getQualityChecks() {
+    return repository.getQualityChecks();
+  }
+
+  Future<void> recordQualityCheck({
+    required String productId,
+    required String productName,
+    required int inspectedQuantity,
+    required int rejectedQuantity,
+    required String shiftSupervisorUid,
+    required String shiftSupervisorName,
+    required String qualityInspectorUid,
+    required String qualityInspectorName,
+    String? defectAnalysis,
+    List<String> imageUrls = const [],
+  }) async {
+    final check = QualityCheckModel(
+      id: '',
+      productId: productId,
+      productName: productName,
+      inspectedQuantity: inspectedQuantity,
+      rejectedQuantity: rejectedQuantity,
+      acceptedQuantity: inspectedQuantity - rejectedQuantity,
+      shiftSupervisorUid: shiftSupervisorUid,
+      shiftSupervisorName: shiftSupervisorName,
+      qualityInspectorUid: qualityInspectorUid,
+      qualityInspectorName: qualityInspectorName,
+      defectAnalysis: defectAnalysis,
+      imageUrls: imageUrls,
+      createdAt: Timestamp.now(),
+    );
+    await repository.addQualityCheck(check);
+  }
+}

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -457,5 +457,13 @@
   "linkedProductionOrder": "أمر الإنتاج المرتبط",
   "sparePartRequestDetails": "تفاصيل طلب قطع الغيار",
   "rejectRequest": "رفض الطلب",
-  "reason": "السبب"
+  "reason": "السبب",
+  "addQualityCheck": "إضافة فحص جودة",
+  "inspectProductDelivery": "فحص المنتجات عند التسليم",
+  "rejectedQuantity": "الكمية المرفوضة",
+  "acceptedQuantity": "الكمية المقبولة",
+  "shiftSupervisor": "مشرف الوردية",
+  "defectAnalysis": "تحليل التالف",
+  "qualityChecks": "سجلات الجودة",
+  "defectPhotos": "صور التالف"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -467,5 +467,13 @@
   "sparePartRequestDetails": "Request Details",
   "rejectRequest": "Reject Request",
   "reason": "Reason",
+  "addQualityCheck": "Add Quality Check",
+  "inspectProductDelivery": "Inspect products upon delivery",
+  "rejectedQuantity": "Rejected Quantity",
+  "acceptedQuantity": "Accepted Quantity",
+  "shiftSupervisor": "Shift Supervisor",
+  "defectAnalysis": "Defect Analysis",
+  "qualityChecks": "Quality Checks",
+  "defectPhotos": "Defect Photos",
   "unknown": "Unknown"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -450,6 +450,14 @@ class AppLocalizations {
   String get sparePartRequestDetails => _strings["sparePartRequestDetails"] ?? "sparePartRequestDetails";
   String get rejectRequest => _strings["rejectRequest"] ?? "rejectRequest";
   String get reason => _strings["reason"] ?? "reason";
+  String get addQualityCheck => _strings["addQualityCheck"] ?? "addQualityCheck";
+  String get inspectProductDelivery => _strings["inspectProductDelivery"] ?? "inspectProductDelivery";
+  String get rejectedQuantity => _strings["rejectedQuantity"] ?? "rejectedQuantity";
+  String get acceptedQuantity => _strings["acceptedQuantity"] ?? "acceptedQuantity";
+  String get shiftSupervisor => _strings["shiftSupervisor"] ?? "shiftSupervisor";
+  String get defectAnalysis => _strings["defectAnalysis"] ?? "defectAnalysis";
+  String get qualityChecks => _strings["qualityChecks"] ?? "qualityChecks";
+  String get defectPhotos => _strings["defectPhotos"] ?? "defectPhotos";
 
 
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,6 +44,9 @@ import 'package:plastic_factory_management/domain/usecases/sales_usecases.dart';
 import 'package:plastic_factory_management/data/datasources/financial_datasource.dart';
 import 'package:plastic_factory_management/data/repositories/financial_repository_impl.dart';
 import 'package:plastic_factory_management/domain/usecases/financial_usecases.dart';
+import 'package:plastic_factory_management/data/datasources/quality_datasource.dart';
+import 'package:plastic_factory_management/data/repositories/quality_repository_impl.dart';
+import 'package:plastic_factory_management/domain/usecases/quality_usecases.dart';
 // استيرادات Notifications
 import 'package:plastic_factory_management/data/datasources/notification_datasource.dart';
 import 'package:plastic_factory_management/data/repositories/notification_repository_impl.dart';
@@ -214,6 +217,20 @@ class MyApp extends StatelessWidget {
           create: (context) => FinancialUseCases(
             Provider.of<FinancialRepositoryImpl>(context, listen: false),
             Provider.of<SalesRepositoryImpl>(context, listen: false),
+          ),
+        ),
+        // Quality Control dependencies
+        Provider<QualityDatasource>(
+          create: (_) => QualityDatasource(),
+        ),
+        Provider<QualityRepositoryImpl>(
+          create: (context) => QualityRepositoryImpl(
+            Provider.of<QualityDatasource>(context, listen: false),
+          ),
+        ),
+        Provider<QualityUseCases>(
+          create: (context) => QualityUseCases(
+            Provider.of<QualityRepositoryImpl>(context, listen: false),
           ),
         ),
       ],

--- a/lib/presentation/quality/quality_check_form_screen.dart
+++ b/lib/presentation/quality/quality_check_form_screen.dart
@@ -1,0 +1,179 @@
+// plastic_factory_management/lib/presentation/quality/quality_check_form_screen.dart
+
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:provider/provider.dart';
+
+import 'package:plastic_factory_management/data/models/product_model.dart';
+import 'package:plastic_factory_management/data/models/user_model.dart';
+import 'package:plastic_factory_management/domain/usecases/inventory_usecases.dart';
+import 'package:plastic_factory_management/domain/usecases/quality_usecases.dart';
+import 'package:plastic_factory_management/l10n/app_localizations.dart';
+import 'package:plastic_factory_management/core/services/file_upload_service.dart';
+
+class QualityCheckFormScreen extends StatefulWidget {
+  const QualityCheckFormScreen({Key? key}) : super(key: key);
+
+  @override
+  State<QualityCheckFormScreen> createState() => _QualityCheckFormScreenState();
+}
+
+class _QualityCheckFormScreenState extends State<QualityCheckFormScreen> {
+  final _formKey = GlobalKey<FormState>();
+  ProductModel? _selectedProduct;
+  final TextEditingController _inspectedController = TextEditingController();
+  final TextEditingController _rejectedController = TextEditingController();
+  final TextEditingController _supervisorController = TextEditingController();
+  final TextEditingController _defectController = TextEditingController();
+
+  final ImagePicker _picker = ImagePicker();
+  final List<File> _images = [];
+  final FileUploadService _uploadService = FileUploadService();
+
+  @override
+  void dispose() {
+    _inspectedController.dispose();
+    _rejectedController.dispose();
+    _supervisorController.dispose();
+    _defectController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickImage() async {
+    final picked = await _picker.pickImage(source: ImageSource.gallery);
+    if (picked != null) {
+      setState(() {
+        _images.add(File(picked.path));
+      });
+    }
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+    final currentUser = Provider.of<UserModel?>(context, listen: false);
+    if (currentUser == null || _selectedProduct == null) return;
+
+    final inspected = int.tryParse(_inspectedController.text) ?? 0;
+    final rejected = int.tryParse(_rejectedController.text) ?? 0;
+    final List<String> urls = [];
+    for (int i = 0; i < _images.length; i++) {
+      final url = await _uploadService.uploadFile(
+          _images[i],
+          'quality_checks/${DateTime.now().millisecondsSinceEpoch}_$i.jpg');
+      if (url != null) urls.add(url);
+    }
+
+    final useCases = Provider.of<QualityUseCases>(context, listen: false);
+    await useCases.recordQualityCheck(
+      productId: _selectedProduct!.id,
+      productName: _selectedProduct!.name,
+      inspectedQuantity: inspected,
+      rejectedQuantity: rejected,
+      shiftSupervisorUid: _supervisorController.text,
+      shiftSupervisorName: _supervisorController.text,
+      qualityInspectorUid: currentUser.uid,
+      qualityInspectorName: currentUser.name,
+      defectAnalysis: _defectController.text,
+      imageUrls: urls,
+    );
+    if (mounted) Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    final inventoryUseCases = Provider.of<InventoryUseCases>(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(loc.addQualityCheck),
+        centerTitle: true,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                StreamBuilder<List<ProductModel>>(
+                  stream: inventoryUseCases.getProducts(),
+                  builder: (context, snapshot) {
+                    if (!snapshot.hasData) {
+                      return const SizedBox.shrink();
+                    }
+                    final products = snapshot.data!;
+                    return DropdownButtonFormField<ProductModel>(
+                      value: _selectedProduct,
+                      decoration:
+                          InputDecoration(labelText: loc.product),
+                      items: products
+                          .map((p) => DropdownMenuItem(
+                                value: p,
+                                child: Text(p.name,
+                                    textDirection: TextDirection.rtl),
+                              ))
+                          .toList(),
+                      onChanged: (val) => setState(() => _selectedProduct = val),
+                      validator: (v) => v == null ? loc.fieldRequired : null,
+                    );
+                  },
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: _inspectedController,
+                  keyboardType: TextInputType.number,
+                  decoration:
+                      InputDecoration(labelText: loc.inspectProductDelivery),
+                  validator: (v) => v == null || v.isEmpty
+                      ? loc.fieldRequired
+                      : null,
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: _rejectedController,
+                  keyboardType: TextInputType.number,
+                  decoration:
+                      InputDecoration(labelText: loc.rejectedQuantity),
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: _supervisorController,
+                  decoration: InputDecoration(labelText: loc.shiftSupervisor),
+                  validator: (v) => v == null || v.isEmpty
+                      ? loc.fieldRequired
+                      : null,
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: _defectController,
+                  decoration: InputDecoration(labelText: loc.defectAnalysis),
+                  maxLines: 3,
+                ),
+                const SizedBox(height: 12),
+                Wrap(
+                  spacing: 8,
+                  children: [
+                    for (final img in _images)
+                      Image.file(img, width: 80, height: 80, fit: BoxFit.cover),
+                    IconButton(
+                      onPressed: _pickImage,
+                      icon: const Icon(Icons.add_a_photo),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 24),
+                ElevatedButton(
+                  onPressed: _submit,
+                  child: Text(loc.save),
+                )
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/quality/quality_inspection_screen.dart
+++ b/lib/presentation/quality/quality_inspection_screen.dart
@@ -1,48 +1,59 @@
 // plastic_factory_management/lib/presentation/quality/quality_inspection_screen.dart
 
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:plastic_factory_management/data/models/quality_check_model.dart';
+import 'package:plastic_factory_management/domain/usecases/quality_usecases.dart';
 import 'package:plastic_factory_management/l10n/app_localizations.dart';
+
+import 'quality_check_form_screen.dart';
 
 class QualityInspectionScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final appLocalizations = AppLocalizations.of(context)!;
+    final loc = AppLocalizations.of(context)!;
+    final useCases = Provider.of<QualityUseCases>(context);
     return Scaffold(
       appBar: AppBar(
-        title: Text(appLocalizations.qualityModule),
+        title: Text(loc.qualityModule),
         centerTitle: true,
       ),
-      body: ListView(
-        padding: const EdgeInsets.all(20),
-        children: const [
-          Text(
-            'المهام المتاحة:',
-            style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-            textDirection: TextDirection.rtl,
-          ),
-          SizedBox(height: 12),
-          ListTile(
-            leading: Icon(Icons.check_circle_outline),
-            title: Text('فحص المنتجات النهائية', textDirection: TextDirection.rtl),
-          ),
-          ListTile(
-            leading: Icon(Icons.photo),
-            title: Text('إرفاق صور وملاحظات توثيقية', textDirection: TextDirection.rtl),
-          ),
-          ListTile(
-            leading: Icon(Icons.thumb_up_alt_outlined),
-            title: Text('الموافقة على السليم ورفض المعيب', textDirection: TextDirection.rtl),
-          ),
-          SizedBox(height: 20),
-          Center(
-            child: Text(
-              'هنا يمكن لمراقب الجودة تسجيل فحوصات الجودة ومراجعة النتائج.',
-              style: TextStyle(fontSize: 16),
-              textAlign: TextAlign.center,
-              textDirection: TextDirection.rtl,
-            ),
-          ),
-        ],
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(builder: (_) => const QualityCheckFormScreen()),
+          );
+        },
+        child: const Icon(Icons.add),
+      ),
+      body: StreamBuilder<List<QualityCheckModel>>(
+        stream: useCases.getQualityChecks(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final checks = snapshot.data ?? [];
+          if (checks.isEmpty) {
+            return Center(child: Text(loc.noData));
+          }
+          return ListView.builder(
+            itemCount: checks.length,
+            itemBuilder: (context, index) {
+              final check = checks[index];
+              return ListTile(
+                title: Text(check.productName, textDirection: TextDirection.rtl),
+                subtitle: Text(
+                  '${loc.rejectedQuantity}: ${check.rejectedQuantity}',
+                  textDirection: TextDirection.rtl,
+                ),
+                trailing: Text(
+                  check.createdAt.toDate().toString().split(' ').first,
+                  style: const TextStyle(fontSize: 12),
+                ),
+              );
+            },
+          );
+        },
       ),
     );
   }


### PR DESCRIPTION
## Summary
- introduce quality check model and Firestore datasource
- implement repository and use cases for quality checks
- provide form to record quality inspections with photos
- list quality checks in quality module screen
- wire up quality providers in `main.dart`
- add localization strings for new features

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864fd3a86bc832aaf612d55d8172f56