### PR TITLE
Add reporting dashboards and root cause analysis

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -465,5 +465,13 @@
   "shiftSupervisor": "مشرف الوردية",
   "defectAnalysis": "تحليل التالف",
   "qualityChecks": "سجلات الجودة",
-  "defectPhotos": "صور التالف"
+  "defectPhotos": "صور التالف",
+  "productionDashboard": "لوحة الإنتاج",
+  "maintenanceDashboard": "لوحة الصيانة",
+  "salesDashboard": "لوحة المبيعات",
+  "inventoryDashboard": "لوحة المخزون",
+  "keyPerformanceIndicators": "مؤشرات الأداء",
+  "rootCauseAnalysis": "تحليل الجذور",
+  "openRootCauseAnalysis": "فتح تحليلات الجذور",
+  "totalOrders": "إجمالي الطلبات"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -475,5 +475,13 @@
   "defectAnalysis": "Defect Analysis",
   "qualityChecks": "Quality Checks",
   "defectPhotos": "Defect Photos",
+  "productionDashboard": "Production Dashboard",
+  "maintenanceDashboard": "Maintenance Dashboard",
+  "salesDashboard": "Sales Dashboard",
+  "inventoryDashboard": "Inventory Dashboard",
+  "keyPerformanceIndicators": "Key Performance Indicators",
+  "rootCauseAnalysis": "Root Cause Analysis",
+  "openRootCauseAnalysis": "Open Root Cause Analysis",
+  "totalOrders": "Total Orders",
   "unknown": "Unknown"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -458,6 +458,14 @@ class AppLocalizations {
   String get defectAnalysis => _strings["defectAnalysis"] ?? "defectAnalysis";
   String get qualityChecks => _strings["qualityChecks"] ?? "qualityChecks";
   String get defectPhotos => _strings["defectPhotos"] ?? "defectPhotos";
+  String get productionDashboard => _strings["productionDashboard"] ?? "productionDashboard";
+  String get maintenanceDashboard => _strings["maintenanceDashboard"] ?? "maintenanceDashboard";
+  String get salesDashboard => _strings["salesDashboard"] ?? "salesDashboard";
+  String get inventoryDashboard => _strings["inventoryDashboard"] ?? "inventoryDashboard";
+  String get keyPerformanceIndicators => _strings["keyPerformanceIndicators"] ?? "keyPerformanceIndicators";
+  String get rootCauseAnalysis => _strings["rootCauseAnalysis"] ?? "rootCauseAnalysis";
+  String get openRootCauseAnalysis => _strings["openRootCauseAnalysis"] ?? "openRootCauseAnalysis";
+  String get totalOrders => _strings["totalOrders"] ?? "totalOrders";
 
 
 }

--- a/lib/presentation/management/reports_screen.dart
+++ b/lib/presentation/management/reports_screen.dart
@@ -1,23 +1,210 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:plastic_factory_management/data/models/maintenance_log_model.dart';
+import 'package:plastic_factory_management/data/models/production_order_model.dart';
+import 'package:plastic_factory_management/data/models/raw_material_model.dart';
+import 'package:plastic_factory_management/data/models/product_model.dart';
+import 'package:plastic_factory_management/data/models/sales_order_model.dart';
+import 'package:plastic_factory_management/domain/usecases/maintenance_usecases.dart';
+import 'package:plastic_factory_management/domain/usecases/production_order_usecases.dart';
+import 'package:plastic_factory_management/domain/usecases/inventory_usecases.dart';
+import 'package:plastic_factory_management/domain/usecases/sales_usecases.dart';
 import 'package:plastic_factory_management/l10n/app_localizations.dart';
+import '../routes/app_router.dart';
 
-class ReportsScreen extends StatelessWidget {
+class ReportsScreen extends StatefulWidget {
   const ReportsScreen({super.key});
 
   @override
+  State<ReportsScreen> createState() => _ReportsScreenState();
+}
+
+class _ReportsScreenState extends State<ReportsScreen>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 4, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final appLocalizations = AppLocalizations.of(context)!;
+    final loc = AppLocalizations.of(context)!;
+    final productionUseCases = Provider.of<ProductionOrderUseCases>(context);
+    final maintenanceUseCases = Provider.of<MaintenanceUseCases>(context);
+    final salesUseCases = Provider.of<SalesUseCases>(context);
+    final inventoryUseCases = Provider.of<InventoryUseCases>(context);
+
     return Scaffold(
       appBar: AppBar(
-        title: Text(appLocalizations.reports),
+        title: Text(loc.reports),
         centerTitle: true,
-      ),
-      body: Center(
-        child: Text(
-          'هنا عرض التقارير والتحليلات',
-          textDirection: TextDirection.rtl,
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: [
+            Tab(text: loc.productionDashboard),
+            Tab(text: loc.maintenanceDashboard),
+            Tab(text: loc.salesDashboard),
+            Tab(text: loc.inventoryDashboard),
+          ],
         ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.analytics_outlined),
+            tooltip: loc.rootCauseAnalysis,
+            onPressed: () =>
+                Navigator.of(context).pushNamed(AppRouter.rootCauseAnalysisRoute),
+          ),
+        ],
       ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          _buildProductionTab(productionUseCases, loc),
+          _buildMaintenanceTab(maintenanceUseCases, loc),
+          _buildSalesTab(salesUseCases, loc),
+          _buildInventoryTab(inventoryUseCases, loc),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildKpi(String label, int value) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          value.toString(),
+          style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 4),
+        Text(label, textDirection: TextDirection.rtl, textAlign: TextAlign.center),
+      ],
+    );
+  }
+
+  Widget _buildProductionTab(
+      ProductionOrderUseCases useCases, AppLocalizations loc) {
+    return StreamBuilder<List<ProductionOrderModel>>(
+      stream: useCases.getProductionOrders(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final orders = snapshot.data ?? [];
+        final completed = orders
+            .where((o) => o.status == ProductionOrderStatus.completed)
+            .length;
+        final inProd = orders
+            .where((o) => o.status == ProductionOrderStatus.inProduction)
+            .length;
+        return Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              _buildKpi(loc.totalOrders, orders.length),
+              _buildKpi(loc.completed, completed),
+              _buildKpi(loc.inProduction, inProd),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildMaintenanceTab(
+      MaintenanceUseCases useCases, AppLocalizations loc) {
+    return StreamBuilder<List<MaintenanceLogModel>>(
+      stream: useCases.getScheduledMaintenance(),
+      builder: (context, scheduledSnap) {
+        if (scheduledSnap.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final scheduled = scheduledSnap.data ?? [];
+        return StreamBuilder<List<MaintenanceLogModel>>(
+          stream: useCases.getCompletedMaintenance(),
+          builder: (context, completedSnap) {
+            if (completedSnap.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            final completed = completedSnap.data ?? [];
+            return Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  _buildKpi(loc.scheduledMaintenance, scheduled.length),
+                  _buildKpi(loc.completedMaintenance, completed.length),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildSalesTab(SalesUseCases useCases, AppLocalizations loc) {
+    return StreamBuilder<List<SalesOrderModel>>(
+      stream: useCases.getSalesOrders(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final orders = snapshot.data ?? [];
+        final fulfilled =
+            orders.where((o) => o.status == SalesOrderStatus.fulfilled).length;
+        return Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              _buildKpi(loc.totalOrders, orders.length),
+              _buildKpi(loc.fulfilled, fulfilled),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildInventoryTab(InventoryUseCases useCases, AppLocalizations loc) {
+    return StreamBuilder<List<RawMaterialModel>>(
+      stream: useCases.getRawMaterials(),
+      builder: (context, rawSnap) {
+        if (rawSnap.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final materials = rawSnap.data ?? [];
+        return StreamBuilder<List<ProductModel>>(
+          stream: useCases.getProducts(),
+          builder: (context, prodSnap) {
+            if (prodSnap.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            final products = prodSnap.data ?? [];
+            return Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  _buildKpi(loc.rawMaterials, materials.length),
+                  _buildKpi(loc.productCatalog, products.length),
+                ],
+              ),
+            );
+          },
+        );
+      },
     );
   }
 }

--- a/lib/presentation/management/root_cause_analysis_screen.dart
+++ b/lib/presentation/management/root_cause_analysis_screen.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:plastic_factory_management/domain/usecases/quality_usecases.dart';
+import 'package:plastic_factory_management/data/models/quality_check_model.dart';
+import 'package:plastic_factory_management/l10n/app_localizations.dart';
+
+class RootCauseAnalysisScreen extends StatelessWidget {
+  const RootCauseAnalysisScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    final qualityUseCases = Provider.of<QualityUseCases>(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(loc.rootCauseAnalysis),
+        centerTitle: true,
+      ),
+      body: StreamBuilder<List<QualityCheckModel>>(
+        stream: qualityUseCases.getQualityChecks(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final checks = snapshot.data ?? [];
+          if (checks.isEmpty) {
+            return Center(child: Text(loc.noData));
+          }
+          final Map<String, int> counts = {};
+          for (final check in checks) {
+            final key = check.defectAnalysis?.trim().isNotEmpty == true
+                ? check.defectAnalysis!
+                : loc.unknown;
+            counts[key] = (counts[key] ?? 0) + 1;
+          }
+          final entries = counts.entries.toList()
+            ..sort((a, b) => b.value.compareTo(a.value));
+          return ListView.builder(
+            itemCount: entries.length,
+            itemBuilder: (context, index) {
+              final entry = entries[index];
+              return ListTile(
+                title: Text(entry.key, textDirection: TextDirection.rtl),
+                trailing: Text(entry.value.toString()),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/presentation/routes/app_router.dart
+++ b/lib/presentation/routes/app_router.dart
@@ -31,6 +31,7 @@ import 'package:plastic_factory_management/presentation/management/user_manageme
 import 'package:plastic_factory_management/presentation/management/returns_screen.dart';
 import 'package:plastic_factory_management/presentation/management/delivery_screen.dart';
 import 'package:plastic_factory_management/presentation/management/reports_screen.dart';
+import 'package:plastic_factory_management/presentation/management/root_cause_analysis_screen.dart';
 import 'package:plastic_factory_management/presentation/management/procurement_screen.dart';
 import 'package:plastic_factory_management/presentation/management/documents_center_screen.dart';
 
@@ -67,6 +68,7 @@ class AppRouter {
   static const String reportsRoute = '/management/reports';
   static const String procurementRoute = '/management/procurement';
   static const String documentsCenterRoute = '/management/documents';
+  static const String rootCauseAnalysisRoute = '/management/root_cause';
   static const String notificationsRoute = '/notifications';
 
   static Route<dynamic> generateRoute(RouteSettings settings) {
@@ -127,6 +129,8 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => DeliveryScreen());
       case reportsRoute:
         return MaterialPageRoute(builder: (_) => ReportsScreen());
+      case rootCauseAnalysisRoute:
+        return MaterialPageRoute(builder: (_) => RootCauseAnalysisScreen());
       case procurementRoute:
         return MaterialPageRoute(builder: (_) => ProcurementScreen());
       case documentsCenterRoute:


### PR DESCRIPTION
## Summary
- enhance translation files with new strings for dashboards and analysis
- expose new localization getters
- implement a tabbed Reports screen with production, maintenance, sales and inventory KPIs
- add Root Cause Analysis screen for defect statistics
- wire new route in `AppRouter`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ff7cd0b0832abff0f07f4443f98b