### PR TITLE
Add returns request workflow

### DIFF
--- a/lib/data/datasources/returns_datasource.dart
+++ b/lib/data/datasources/returns_datasource.dart
@@ -1,0 +1,26 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/return_request_model.dart';
+
+class ReturnsDatasource {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+
+  Stream<List<ReturnRequestModel>> getReturnRequests() {
+    return _firestore
+        .collection('return_requests')
+        .snapshots()
+        .map((snapshot) => snapshot.docs
+            .map((d) => ReturnRequestModel.fromDocumentSnapshot(d))
+            .toList());
+  }
+
+  Future<void> addReturnRequest(ReturnRequestModel request) async {
+    await _firestore.collection('return_requests').add(request.toMap());
+  }
+
+  Future<void> updateReturnRequest(ReturnRequestModel request) async {
+    await _firestore
+        .collection('return_requests')
+        .doc(request.id)
+        .update(request.toMap());
+  }
+}

--- a/lib/data/models/return_request_model.dart
+++ b/lib/data/models/return_request_model.dart
@@ -1,0 +1,143 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+enum ReturnRequestStatus {
+  pendingOperations,
+  pendingSalesApproval,
+  awaitingPickup,
+  completed,
+}
+
+extension ReturnRequestStatusExtension on ReturnRequestStatus {
+  String toFirestoreString() => name;
+  static ReturnRequestStatus fromString(String status) {
+    return ReturnRequestStatus.values.firstWhere(
+      (e) => e.name == status,
+      orElse: () => ReturnRequestStatus.pendingOperations,
+    );
+  }
+
+  String toArabicString() {
+    switch (this) {
+      case ReturnRequestStatus.pendingOperations:
+        return 'بانتظار مراجعة العمليات';
+      case ReturnRequestStatus.pendingSalesApproval:
+        return 'بانتظار اعتماد المبيعات';
+      case ReturnRequestStatus.awaitingPickup:
+        return 'بانتظار الاستلام';
+      case ReturnRequestStatus.completed:
+        return 'مكتمل';
+    }
+  }
+}
+
+class ReturnRequestModel {
+  final String id;
+  final String requesterUid;
+  final String requesterName;
+  final String reason;
+  final ReturnRequestStatus status;
+  final Timestamp createdAt;
+  final String? operationsUid;
+  final String? operationsName;
+  final Timestamp? operationsApprovedAt;
+  final String? salesManagerUid;
+  final String? salesManagerName;
+  final Timestamp? salesApprovedAt;
+  final String? driverName;
+  final String? warehouseKeeperName;
+  final Timestamp? pickupScheduledAt;
+
+  ReturnRequestModel({
+    required this.id,
+    required this.requesterUid,
+    required this.requesterName,
+    required this.reason,
+    required this.status,
+    required this.createdAt,
+    this.operationsUid,
+    this.operationsName,
+    this.operationsApprovedAt,
+    this.salesManagerUid,
+    this.salesManagerName,
+    this.salesApprovedAt,
+    this.driverName,
+    this.warehouseKeeperName,
+    this.pickupScheduledAt,
+  });
+
+  factory ReturnRequestModel.fromDocumentSnapshot(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return ReturnRequestModel(
+      id: doc.id,
+      requesterUid: data['requesterUid'] ?? '',
+      requesterName: data['requesterName'] ?? '',
+      reason: data['reason'] ?? '',
+      status: ReturnRequestStatusExtension.fromString(data['status'] ?? 'pendingOperations'),
+      createdAt: data['createdAt'] ?? Timestamp.now(),
+      operationsUid: data['operationsUid'],
+      operationsName: data['operationsName'],
+      operationsApprovedAt: data['operationsApprovedAt'],
+      salesManagerUid: data['salesManagerUid'],
+      salesManagerName: data['salesManagerName'],
+      salesApprovedAt: data['salesApprovedAt'],
+      driverName: data['driverName'],
+      warehouseKeeperName: data['warehouseKeeperName'],
+      pickupScheduledAt: data['pickupScheduledAt'],
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'requesterUid': requesterUid,
+      'requesterName': requesterName,
+      'reason': reason,
+      'status': status.toFirestoreString(),
+      'createdAt': createdAt,
+      'operationsUid': operationsUid,
+      'operationsName': operationsName,
+      'operationsApprovedAt': operationsApprovedAt,
+      'salesManagerUid': salesManagerUid,
+      'salesManagerName': salesManagerName,
+      'salesApprovedAt': salesApprovedAt,
+      'driverName': driverName,
+      'warehouseKeeperName': warehouseKeeperName,
+      'pickupScheduledAt': pickupScheduledAt,
+    };
+  }
+
+  ReturnRequestModel copyWith({
+    String? id,
+    String? requesterUid,
+    String? requesterName,
+    String? reason,
+    ReturnRequestStatus? status,
+    Timestamp? createdAt,
+    String? operationsUid,
+    String? operationsName,
+    Timestamp? operationsApprovedAt,
+    String? salesManagerUid,
+    String? salesManagerName,
+    Timestamp? salesApprovedAt,
+    String? driverName,
+    String? warehouseKeeperName,
+    Timestamp? pickupScheduledAt,
+  }) {
+    return ReturnRequestModel(
+      id: id ?? this.id,
+      requesterUid: requesterUid ?? this.requesterUid,
+      requesterName: requesterName ?? this.requesterName,
+      reason: reason ?? this.reason,
+      status: status ?? this.status,
+      createdAt: createdAt ?? this.createdAt,
+      operationsUid: operationsUid ?? this.operationsUid,
+      operationsName: operationsName ?? this.operationsName,
+      operationsApprovedAt: operationsApprovedAt ?? this.operationsApprovedAt,
+      salesManagerUid: salesManagerUid ?? this.salesManagerUid,
+      salesManagerName: salesManagerName ?? this.salesManagerName,
+      salesApprovedAt: salesApprovedAt ?? this.salesApprovedAt,
+      driverName: driverName ?? this.driverName,
+      warehouseKeeperName: warehouseKeeperName ?? this.warehouseKeeperName,
+      pickupScheduledAt: pickupScheduledAt ?? this.pickupScheduledAt,
+    );
+  }
+}

--- a/lib/data/repositories/returns_repository_impl.dart
+++ b/lib/data/repositories/returns_repository_impl.dart
@@ -1,0 +1,23 @@
+import '../datasources/returns_datasource.dart';
+import '../models/return_request_model.dart';
+import '../../domain/repositories/returns_repository.dart';
+
+class ReturnsRepositoryImpl implements ReturnsRepository {
+  final ReturnsDatasource datasource;
+  ReturnsRepositoryImpl(this.datasource);
+
+  @override
+  Stream<List<ReturnRequestModel>> getReturnRequests() {
+    return datasource.getReturnRequests();
+  }
+
+  @override
+  Future<void> addReturnRequest(ReturnRequestModel request) {
+    return datasource.addReturnRequest(request);
+  }
+
+  @override
+  Future<void> updateReturnRequest(ReturnRequestModel request) {
+    return datasource.updateReturnRequest(request);
+  }
+}

--- a/lib/domain/repositories/returns_repository.dart
+++ b/lib/domain/repositories/returns_repository.dart
@@ -1,0 +1,7 @@
+import '../../data/models/return_request_model.dart';
+
+abstract class ReturnsRepository {
+  Stream<List<ReturnRequestModel>> getReturnRequests();
+  Future<void> addReturnRequest(ReturnRequestModel request);
+  Future<void> updateReturnRequest(ReturnRequestModel request);
+}

--- a/lib/domain/usecases/returns_usecases.dart
+++ b/lib/domain/usecases/returns_usecases.dart
@@ -1,0 +1,55 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../data/models/return_request_model.dart';
+import '../repositories/returns_repository.dart';
+
+class ReturnsUseCases {
+  final ReturnsRepository repository;
+  ReturnsUseCases(this.repository);
+
+  Stream<List<ReturnRequestModel>> getReturnRequests() {
+    return repository.getReturnRequests();
+  }
+
+  Future<void> createReturnRequest(ReturnRequestModel request) async {
+    await repository.addReturnRequest(request);
+  }
+
+  Future<void> approveOperations(
+      ReturnRequestModel request, String uid, String name) async {
+    final updated = request.copyWith(
+      status: ReturnRequestStatus.pendingSalesApproval,
+      operationsUid: uid,
+      operationsName: name,
+      operationsApprovedAt: Timestamp.now(),
+    );
+    await repository.updateReturnRequest(updated);
+  }
+
+  Future<void> approveSales(
+      ReturnRequestModel request, String uid, String name) async {
+    final updated = request.copyWith(
+      status: ReturnRequestStatus.awaitingPickup,
+      salesManagerUid: uid,
+      salesManagerName: name,
+      salesApprovedAt: Timestamp.now(),
+    );
+    await repository.updateReturnRequest(updated);
+  }
+
+  Future<void> schedulePickup(ReturnRequestModel request,
+      {required String driverName,
+      required String warehouseKeeperName}) async {
+    final updated = request.copyWith(
+      status: ReturnRequestStatus.awaitingPickup,
+      driverName: driverName,
+      warehouseKeeperName: warehouseKeeperName,
+      pickupScheduledAt: Timestamp.now(),
+    );
+    await repository.updateReturnRequest(updated);
+  }
+
+  Future<void> markCompleted(ReturnRequestModel request) async {
+    final updated = request.copyWith(status: ReturnRequestStatus.completed);
+    await repository.updateReturnRequest(updated);
+  }
+}

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -479,4 +479,12 @@
   "rootCauseAnalysis": "تحليل الجذور",
   "openRootCauseAnalysis": "فتح تحليلات الجذور",
   "totalOrders": "إجمالي الطلبات"
+  ,"returnRequests": "طلبات المرتجع"
+  ,"addReturnRequest": "إضافة طلب مرتجع"
+  ,"operationsReview": "اعتماد العمليات"
+  ,"salesApproval": "اعتماد المبيعات"
+  ,"schedulePickup": "تنسيق الاستلام"
+  ,"driver": "السائق"
+  ,"warehouseKeeper": "أمين المخزن"
+  ,"complete": "إكمال"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -488,5 +488,13 @@
   "rootCauseAnalysis": "Root Cause Analysis",
   "openRootCauseAnalysis": "Open Root Cause Analysis",
   "totalOrders": "Total Orders",
+  "returnRequests": "Return Requests",
+  "addReturnRequest": "Add Return Request",
+  "operationsReview": "Operations Review",
+  "salesApproval": "Sales Approval",
+  "schedulePickup": "Schedule Pickup",
+  "driver": "Driver",
+  "warehouseKeeper": "Warehouse Keeper",
+  "complete": "Complete",
   "unknown": "Unknown"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -439,6 +439,14 @@ class AppLocalizations {
   String get purchasesManagement => _strings["purchasesManagement"] ?? "purchasesManagement";
   String get sparePartRequests => _strings["sparePartRequests"] ?? "sparePartRequests";
   String get purchaseRequests => _strings["purchaseRequests"] ?? "purchaseRequests";
+  String get returnRequests => _strings["returnRequests"] ?? "returnRequests";
+  String get addReturnRequest => _strings["addReturnRequest"] ?? "addReturnRequest";
+  String get operationsReview => _strings["operationsReview"] ?? "operationsReview";
+  String get salesApproval => _strings["salesApproval"] ?? "salesApproval";
+  String get schedulePickup => _strings["schedulePickup"] ?? "schedulePickup";
+  String get driver => _strings["driver"] ?? "driver";
+  String get warehouseKeeper => _strings["warehouseKeeper"] ?? "warehouseKeeper";
+  String get complete => _strings["complete"] ?? "complete";
   String get addPurchaseRequest => _strings["addPurchaseRequest"] ?? "addPurchaseRequest";
   String get inventoryReview => _strings["inventoryReview"] ?? "inventoryReview";
   String get sendToSuppliers => _strings["sendToSuppliers"] ?? "sendToSuppliers";

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -50,6 +50,9 @@ import 'package:plastic_factory_management/domain/usecases/quality_usecases.dart
 import 'package:plastic_factory_management/data/datasources/procurement_datasource.dart';
 import 'package:plastic_factory_management/data/repositories/procurement_repository_impl.dart';
 import 'package:plastic_factory_management/domain/usecases/procurement_usecases.dart';
+import 'package:plastic_factory_management/data/datasources/returns_datasource.dart';
+import 'package:plastic_factory_management/data/repositories/returns_repository_impl.dart';
+import 'package:plastic_factory_management/domain/usecases/returns_usecases.dart';
 // استيرادات Notifications
 import 'package:plastic_factory_management/data/datasources/notification_datasource.dart';
 import 'package:plastic_factory_management/data/repositories/notification_repository_impl.dart';
@@ -249,6 +252,20 @@ class MyApp extends StatelessWidget {
         Provider<QualityUseCases>(
           create: (context) => QualityUseCases(
             Provider.of<QualityRepositoryImpl>(context, listen: false),
+          ),
+        ),
+        // Returns dependencies
+        Provider<ReturnsDatasource>(
+          create: (_) => ReturnsDatasource(),
+        ),
+        Provider<ReturnsRepositoryImpl>(
+          create: (context) => ReturnsRepositoryImpl(
+            Provider.of<ReturnsDatasource>(context, listen: false),
+          ),
+        ),
+        Provider<ReturnsUseCases>(
+          create: (context) => ReturnsUseCases(
+            Provider.of<ReturnsRepositoryImpl>(context, listen: false),
           ),
         ),
       ],

--- a/lib/presentation/management/returns_screen.dart
+++ b/lib/presentation/management/returns_screen.dart
@@ -1,5 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:plastic_factory_management/l10n/app_localizations.dart';
+import 'package:plastic_factory_management/data/models/return_request_model.dart';
+import 'package:plastic_factory_management/data/models/user_model.dart';
+import 'package:plastic_factory_management/domain/usecases/returns_usecases.dart';
+import 'package:plastic_factory_management/core/constants/app_enums.dart';
 
 class ReturnsScreen extends StatelessWidget {
   const ReturnsScreen({super.key});
@@ -7,17 +13,176 @@ class ReturnsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final appLocalizations = AppLocalizations.of(context)!;
+    final useCases = Provider.of<ReturnsUseCases>(context);
+    final currentUser = Provider.of<UserModel?>(context);
+
     return Scaffold(
       appBar: AppBar(
         title: Text(appLocalizations.returns),
         centerTitle: true,
+        actions: [
+          if (currentUser != null)
+            IconButton(
+              icon: const Icon(Icons.add),
+              onPressed: () =>
+                  _showAddDialog(context, useCases, currentUser, appLocalizations),
+            ),
+        ],
       ),
-      body: Center(
-        child: Text(
-          'هنا يمكن إدارة وحدة المرتجع',
-          textDirection: TextDirection.rtl,
-        ),
+      body: StreamBuilder<List<ReturnRequestModel>>(
+        stream: useCases.getReturnRequests(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final requests = snapshot.data ?? [];
+          if (requests.isEmpty) {
+            return Center(child: Text(appLocalizations.noData));
+          }
+          return ListView.builder(
+            itemCount: requests.length,
+            itemBuilder: (context, index) {
+              final r = requests[index];
+              return Card(
+                margin: const EdgeInsets.all(8),
+                child: ListTile(
+                  title: Text(r.requesterName, textDirection: TextDirection.rtl),
+                  subtitle:
+                      Text(r.status.toArabicString(), textDirection: TextDirection.rtl),
+                  onTap: () => _showRequestDialog(
+                      context, r, useCases, currentUser, appLocalizations),
+                ),
+              );
+            },
+          );
+        },
       ),
     );
   }
+}
+
+void _showAddDialog(BuildContext context, ReturnsUseCases useCases, UserModel user,
+    AppLocalizations appLocalizations) {
+  final reasonController = TextEditingController();
+  showDialog(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text(appLocalizations.addReturnRequest, textAlign: TextAlign.center),
+      content: TextField(
+        controller: reasonController,
+        decoration: InputDecoration(labelText: appLocalizations.reason),
+        textDirection: TextDirection.rtl,
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: Text(appLocalizations.cancel),
+        ),
+        ElevatedButton(
+          onPressed: () async {
+            final request = ReturnRequestModel(
+              id: '',
+              requesterUid: user.uid,
+              requesterName: user.name,
+              reason: reasonController.text,
+              status: ReturnRequestStatus.pendingOperations,
+              createdAt: Timestamp.now(),
+            );
+            await useCases.createReturnRequest(request);
+            Navigator.pop(context);
+          },
+          child: Text(appLocalizations.save),
+        ),
+      ],
+    ),
+  );
+}
+
+void _showRequestDialog(
+    BuildContext context,
+    ReturnRequestModel request,
+    ReturnsUseCases useCases,
+    UserModel? user,
+    AppLocalizations appLocalizations) {
+  final driverController = TextEditingController();
+  final warehouseController = TextEditingController();
+  showDialog(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text(appLocalizations.returnRequests, textAlign: TextAlign.center),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('${appLocalizations.reason}: ${request.reason}',
+              textDirection: TextDirection.rtl),
+          const SizedBox(height: 8),
+          Text(appLocalizations.statusColon +
+              request.status.toArabicString(),
+              textDirection: TextDirection.rtl),
+          if (request.status == ReturnRequestStatus.awaitingPickup) ...[
+            const SizedBox(height: 8),
+            TextField(
+              controller: driverController,
+              decoration: InputDecoration(labelText: appLocalizations.driver),
+              textDirection: TextDirection.rtl,
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: warehouseController,
+              decoration:
+                  InputDecoration(labelText: appLocalizations.warehouseKeeper),
+              textDirection: TextDirection.rtl,
+            ),
+          ],
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: Text(appLocalizations.cancel),
+        ),
+        if (user != null &&
+            user.userRoleEnum == UserRole.operationsOfficer &&
+            request.status == ReturnRequestStatus.pendingOperations)
+          TextButton(
+            onPressed: () async {
+              await useCases.approveOperations(request, user.uid, user.name);
+              Navigator.pop(context);
+            },
+            child: Text(appLocalizations.operationsReview),
+          ),
+        if (user != null &&
+            user.userRoleEnum == UserRole.salesRepresentative &&
+            request.status == ReturnRequestStatus.pendingSalesApproval)
+          TextButton(
+            onPressed: () async {
+              await useCases.approveSales(request, user.uid, user.name);
+              Navigator.pop(context);
+            },
+            child: Text(appLocalizations.salesApproval),
+          ),
+        if (user != null &&
+            request.status == ReturnRequestStatus.awaitingPickup)
+          TextButton(
+            onPressed: () async {
+              await useCases.schedulePickup(request,
+                  driverName: driverController.text,
+                  warehouseKeeperName: warehouseController.text);
+              Navigator.pop(context);
+            },
+            child: Text(appLocalizations.schedulePickup),
+          ),
+        if (user != null &&
+            request.status == ReturnRequestStatus.awaitingPickup)
+          TextButton(
+            onPressed: () async {
+              await useCases.markCompleted(request);
+              Navigator.pop(context);
+            },
+            child: Text(appLocalizations.complete),
+          ),
+      ],
+    ),
+  );
 }


### PR DESCRIPTION
## Summary
- implement `ReturnRequestModel` with workflow fields
- create datasource, repository and usecases for returns
- provide returns dependencies in `main.dart`
- enhance ReturnsScreen to handle creating and approving return requests
- add localization strings for new functionality

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865061e6564832aa5d7880e8638fe5b