### PR TITLE
Add delivery scheduling with driver assignment

### DIFF
--- a/lib/core/constants/app_enums.dart
+++ b/lib/core/constants/app_enums.dart
@@ -13,6 +13,7 @@ enum UserRole {
   qualityInspector, // مراقب الجودة
   inventoryManager, // أمين المخزن
   accountant, // المحاسب
+  driver, // سائق التوصيل
   unknown, // دور غير معروف
 }
 
@@ -44,6 +45,8 @@ extension UserRoleExtension on UserRole {
         return 'أمين المخزن';
       case UserRole.accountant:
         return 'المحاسب';
+      case UserRole.driver:
+        return 'سائق التوصيل';
       case UserRole.unknown:
       default:
         return 'غير معروف';
@@ -78,6 +81,8 @@ extension UserRoleExtension on UserRole {
         return UserRole.inventoryManager;
       case 'accountant':
         return UserRole.accountant;
+      case 'driver':
+        return UserRole.driver;
       default:
         return UserRole.unknown;
     }
@@ -110,9 +115,33 @@ extension UserRoleExtension on UserRole {
         return 'inventory_manager';
       case UserRole.accountant:
         return 'accountant';
+      case UserRole.driver:
+        return 'driver';
       case UserRole.unknown:
       default:
         return 'unknown';
     }
+  }
+}
+
+enum TransportMode { company, external }
+
+extension TransportModeExtension on TransportMode {
+  String toArabicString() {
+    switch (this) {
+      case TransportMode.company:
+        return 'شركة';
+      case TransportMode.external:
+        return 'خارجي';
+    }
+  }
+
+  String toFirestoreString() => name;
+
+  static TransportMode fromString(String value) {
+    return TransportMode.values.firstWhere(
+      (e) => e.name == value,
+      orElse: () => TransportMode.company,
+    );
   }
 }

--- a/lib/data/models/sales_order_model.dart
+++ b/lib/data/models/sales_order_model.dart
@@ -1,6 +1,7 @@
 // plastic_factory_management/lib/data/models/sales_order_model.dart
 
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:plastic_factory_management/core/constants/app_enums.dart';
 
 // Enum for Sales Order Status
 enum SalesOrderStatus {
@@ -114,6 +115,9 @@ class SalesOrderModel {
   final String? warehouseManagerUid; // UID أمين المخزن المسؤول
   final String? warehouseManagerName; // اسم أمين المخزن المسؤول
   final Timestamp? deliveryTime; // موعد التسليم المحدد من أمين المخزن
+  final TransportMode? transportMode; // وسيلة النقل
+  final String? driverUid; // UID السائق
+  final String? driverName; // اسم السائق
   final String? productionManagerUid; // UID مسؤول الإنتاج
   final String? productionManagerName; // اسم مسؤول الإنتاج
   final String? productionRejectionReason; // سبب رفض الإنتاج
@@ -144,6 +148,9 @@ class SalesOrderModel {
     this.warehouseManagerUid,
     this.warehouseManagerName,
     this.deliveryTime,
+    this.transportMode,
+    this.driverUid,
+    this.driverName,
     this.productionManagerUid,
     this.productionManagerName,
     this.productionRejectionReason,
@@ -180,6 +187,11 @@ class SalesOrderModel {
       warehouseManagerUid: data['warehouseManagerUid'],
       warehouseManagerName: data['warehouseManagerName'],
       deliveryTime: data['deliveryTime'],
+      transportMode: data['transportMode'] != null
+          ? TransportModeExtension.fromString(data['transportMode'])
+          : null,
+      driverUid: data['driverUid'],
+      driverName: data['driverName'],
       productionManagerUid: data['productionManagerUid'],
       productionManagerName: data['productionManagerName'],
       productionRejectionReason: data['productionRejectionReason'],
@@ -212,6 +224,9 @@ class SalesOrderModel {
       'warehouseManagerUid': warehouseManagerUid,
       'warehouseManagerName': warehouseManagerName,
       'deliveryTime': deliveryTime,
+      'transportMode': transportMode?.toFirestoreString(),
+      'driverUid': driverUid,
+      'driverName': driverName,
       'productionManagerUid': productionManagerUid,
       'productionManagerName': productionManagerName,
       'productionRejectionReason': productionRejectionReason,
@@ -244,6 +259,9 @@ class SalesOrderModel {
     String? warehouseManagerUid,
     String? warehouseManagerName,
     Timestamp? deliveryTime,
+    TransportMode? transportMode,
+    String? driverUid,
+    String? driverName,
     String? productionManagerUid,
     String? productionManagerName,
     String? productionRejectionReason,
@@ -274,6 +292,9 @@ class SalesOrderModel {
       warehouseManagerUid: warehouseManagerUid ?? this.warehouseManagerUid,
       warehouseManagerName: warehouseManagerName ?? this.warehouseManagerName,
       deliveryTime: deliveryTime ?? this.deliveryTime,
+      transportMode: transportMode ?? this.transportMode,
+      driverUid: driverUid ?? this.driverUid,
+      driverName: driverName ?? this.driverName,
       productionManagerUid: productionManagerUid ?? this.productionManagerUid,
       productionManagerName: productionManagerName ?? this.productionManagerName,
       productionRejectionReason: productionRejectionReason ?? this.productionRejectionReason,

--- a/lib/domain/usecases/sales_usecases.dart
+++ b/lib/domain/usecases/sales_usecases.dart
@@ -255,6 +255,22 @@ class SalesUseCases {
     await repository.updateSalesOrder(updated);
   }
 
+  Future<void> scheduleDelivery({
+    required SalesOrderModel order,
+    required DateTime deliveryTime,
+    required TransportMode transportMode,
+    String? driverUid,
+    String? driverName,
+  }) async {
+    final updated = order.copyWith(
+      deliveryTime: Timestamp.fromDate(deliveryTime),
+      transportMode: transportMode,
+      driverUid: driverUid,
+      driverName: driverName,
+    );
+    await repository.updateSalesOrder(updated);
+  }
+
   // Production manager approves supply
   Future<void> approveSupply(SalesOrderModel order, UserModel manager,
       InventoryUseCases inventoryUseCases) async {

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -485,6 +485,11 @@
   ,"salesApproval": "اعتماد المبيعات"
   ,"schedulePickup": "تنسيق الاستلام"
   ,"driver": "السائق"
-  ,"warehouseKeeper": "أمين المخزن"
-  ,"complete": "إكمال"
+  ,"warehouseKeeper": "أمين المخزن",
+  ,"complete": "إكمال",
+  "scheduleDelivery": "جدولة التوصيل",
+  "transportMode": "وسيلة النقل",
+  "companyTransport": "سيارة الشركة",
+  "externalTransport": "خارجي",
+  "deliverySchedule": "جدول التوصيل"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -496,5 +496,10 @@
   "driver": "Driver",
   "warehouseKeeper": "Warehouse Keeper",
   "complete": "Complete",
+  "scheduleDelivery": "Schedule Delivery",
+  "transportMode": "Transport Mode",
+  "companyTransport": "Company Vehicle",
+  "externalTransport": "External",
+  "deliverySchedule": "Delivery Schedule",
   "unknown": "Unknown"
 }

--- a/lib/presentation/management/delivery_screen.dart
+++ b/lib/presentation/management/delivery_screen.dart
@@ -2,8 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart' as intl;
 import 'package:provider/provider.dart';
 import 'package:plastic_factory_management/l10n/app_localizations.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:plastic_factory_management/domain/usecases/sales_usecases.dart';
+import 'package:plastic_factory_management/domain/usecases/user_usecases.dart';
 import 'package:plastic_factory_management/data/models/sales_order_model.dart';
+import 'package:plastic_factory_management/core/constants/app_enums.dart';
+import 'package:plastic_factory_management/data/models/user_model.dart';
 
 class DeliveryScreen extends StatelessWidget {
   const DeliveryScreen({super.key});
@@ -12,6 +16,7 @@ class DeliveryScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final appLocalizations = AppLocalizations.of(context)!;
     final salesUseCases = Provider.of<SalesUseCases>(context);
+    final userUseCases = Provider.of<UserUseCases>(context, listen: false);
     return Scaffold(
       appBar: AppBar(
         title: Text(appLocalizations.delivery),
@@ -39,13 +44,133 @@ class DeliveryScreen extends StatelessWidget {
               final order = orders[index];
               return ListTile(
                 title: Text(order.customerName, textDirection: TextDirection.rtl),
-                subtitle: Text(intl.DateFormat('yyyy-MM-dd HH:mm').format(order.deliveryTime!.toDate()), textDirection: TextDirection.rtl),
-                trailing: Text(order.status.toArabicString(), textDirection: TextDirection.rtl),
+                subtitle: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(intl.DateFormat('yyyy-MM-dd HH:mm').format(order.deliveryTime!.toDate()), textDirection: TextDirection.rtl),
+                    if (order.driverName != null)
+                      Text('${order.driverName} - ${order.transportMode?.toArabicString() ?? ''}', textDirection: TextDirection.rtl),
+                  ],
+                ),
+                trailing: IconButton(
+                  icon: const Icon(Icons.edit),
+                  onPressed: () {
+                    _showScheduleDialog(context, salesUseCases, userUseCases, order, appLocalizations);
+                  },
+                ),
               );
             },
           );
         },
       ),
+    );
+  }
+
+  void _showScheduleDialog(BuildContext context, SalesUseCases salesUseCases,
+      UserUseCases userUseCases, SalesOrderModel order, AppLocalizations loc) {
+    DateTime selectedTime = order.deliveryTime?.toDate() ?? DateTime.now();
+    TransportMode mode = order.transportMode ?? TransportMode.company;
+    UserModel? selectedDriver;
+
+    showDialog(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(builder: (context, setState) {
+          return AlertDialog(
+            title: Text(loc.scheduleDelivery, textAlign: TextAlign.center),
+            content: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ElevatedButton(
+                    onPressed: () async {
+                      final date = await showDatePicker(
+                        context: context,
+                        initialDate: selectedTime,
+                        firstDate: DateTime.now(),
+                        lastDate: DateTime.now().add(const Duration(days: 365)),
+                      );
+                      if (date != null) {
+                        final time = await showTimePicker(
+                          context: context,
+                          initialTime: TimeOfDay.fromDateTime(selectedTime),
+                        );
+                        if (time != null) {
+                          setState(() {
+                            selectedTime = DateTime(
+                              date.year,
+                              date.month,
+                              date.day,
+                              time.hour,
+                              time.minute,
+                            );
+                          });
+                        }
+                      }
+                    },
+                    child: Text(intl.DateFormat('yyyy-MM-dd HH:mm')
+                        .format(selectedTime)),
+                  ),
+                  const SizedBox(height: 12),
+                  DropdownButton<TransportMode>(
+                    value: mode,
+                    onChanged: (val) => setState(() => mode = val!),
+                    items: TransportMode.values
+                        .map((e) => DropdownMenuItem(
+                              value: e,
+                              child:
+                                  Text(e.toArabicString(), textDirection: TextDirection.rtl),
+                            ))
+                        .toList(),
+                  ),
+                  const SizedBox(height: 12),
+                  FutureBuilder<List<UserModel>>(
+                    future: userUseCases.getUsersByRole(UserRole.driver),
+                    builder: (context, snap) {
+                      if (!snap.hasData) {
+                        return const SizedBox();
+                      }
+                      final drivers = snap.data!;
+                      return DropdownButton<UserModel>(
+                        value: drivers.firstWhere(
+                            (d) => d.uid == (selectedDriver?.uid ?? order.driverUid),
+                            orElse: () => drivers.isNotEmpty ? drivers.first : UserModel(uid: '', email: '', name: '', role: UserRole.driver.toFirestoreString(), createdAt: Timestamp.now())),
+                        hint: Text(loc.driver),
+                        onChanged: (val) => setState(() => selectedDriver = val),
+                        items: drivers
+                            .map((d) => DropdownMenuItem(
+                                  value: d,
+                                  child: Text(d.name, textDirection: TextDirection.rtl),
+                                ))
+                            .toList(),
+                      );
+                    },
+                  ),
+                ],
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: Text(loc.cancel),
+              ),
+              ElevatedButton(
+                onPressed: () async {
+                  await salesUseCases.scheduleDelivery(
+                    order: order,
+                    deliveryTime: selectedTime,
+                    transportMode: mode,
+                    driverUid: selectedDriver?.uid,
+                    driverName: selectedDriver?.name,
+                  );
+                  Navigator.pop(context);
+                },
+                child: Text(loc.save),
+              ),
+            ],
+          );
+        });
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- support `driver` role and new `TransportMode` enum
- extend `SalesOrderModel` with driver info and transport mode
- add `scheduleDelivery` in Sales use cases
- enhance Delivery screen to assign drivers and transport mode
- localize new delivery fields

## Testing
- `dart` and `flutter` commands were unavailable so formatting could not be run

------
https://chatgpt.com/codex/tasks/task_e_6865086260e8832abdd25abc886d593d