### PR TITLE
Fix scheduleDelivery localization getter

### DIFF
--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -447,6 +447,11 @@ class AppLocalizations {
   String get driver => _strings["driver"] ?? "driver";
   String get warehouseKeeper => _strings["warehouseKeeper"] ?? "warehouseKeeper";
   String get complete => _strings["complete"] ?? "complete";
+  String get scheduleDelivery => _strings["scheduleDelivery"] ?? "scheduleDelivery";
+  String get transportMode => _strings["transportMode"] ?? "transportMode";
+  String get companyTransport => _strings["companyTransport"] ?? "companyTransport";
+  String get externalTransport => _strings["externalTransport"] ?? "externalTransport";
+  String get deliverySchedule => _strings["deliverySchedule"] ?? "deliverySchedule";
   String get addPurchaseRequest => _strings["addPurchaseRequest"] ?? "addPurchaseRequest";
   String get inventoryReview => _strings["inventoryReview"] ?? "inventoryReview";
   String get sendToSuppliers => _strings["sendToSuppliers"] ?? "sendToSuppliers";


### PR DESCRIPTION
## Summary
- add missing getters for scheduleDelivery and related strings in `AppLocalizations`

## Testing
- `N/A` *(dart/flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68650a61da7c832a9ceeb00e7876189f