### PR TITLE
Add localization keys for reports and finance module

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -445,6 +445,8 @@
   "creditLimitExceeded": "لا يمكن اعتماد الطلب لتجاوز المديونية الحد الائتماني",
   "paymentsManagement": "إدارة الدفعات",
   "purchasesManagement": "إدارة المشتريات",
+  "budgetReview": "التحقق من الموازنات",
+  "accountingOverview": "يمكن للمحاسب هنا مراجعة واعتماد طلبات المبيعات ومتابعة التقارير المالية.",
   "sparePartRequests": "طلبات قطع الغيار",
   "purchaseRequests": "طلبات الشراء",
   "addPurchaseRequest": "إضافة طلب شراء",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -454,6 +454,8 @@
   "creditLimitExceeded": "Cannot approve order: credit limit exceeded",
   "paymentsManagement": "Payments",
   "purchasesManagement": "Purchases",
+  "budgetReview": "Budget Review",
+  "accountingOverview": "The accountant can review and approve sales orders and monitor financial reports.",
   "sparePartRequests": "Spare Part Requests",
   "purchaseRequests": "Purchase Requests",
   "addPurchaseRequest": "Add Purchase Request",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -437,6 +437,8 @@ class AppLocalizations {
   String get creditLimitExceeded => _strings["creditLimitExceeded"] ?? "creditLimitExceeded";
   String get paymentsManagement => _strings["paymentsManagement"] ?? "paymentsManagement";
   String get purchasesManagement => _strings["purchasesManagement"] ?? "purchasesManagement";
+  String get budgetReview => _strings["budgetReview"] ?? "budgetReview";
+  String get accountingOverview => _strings["accountingOverview"] ?? "accountingOverview";
   String get sparePartRequests => _strings["sparePartRequests"] ?? "sparePartRequests";
   String get purchaseRequests => _strings["purchaseRequests"] ?? "purchaseRequests";
   String get returnRequests => _strings["returnRequests"] ?? "returnRequests";

--- a/lib/presentation/accounting/accounting_screen.dart
+++ b/lib/presentation/accounting/accounting_screen.dart
@@ -22,7 +22,7 @@ class AccountingScreen extends StatelessWidget {
       ),
       _AccountingOption(
         icon: Icons.account_balance_wallet_outlined,
-        label: 'التحقق من الموازنات',
+        label: appLocalizations.budgetReview,
         route: null,
       ),
       _AccountingOption(
@@ -49,7 +49,7 @@ class AccountingScreen extends StatelessWidget {
         padding: const EdgeInsets.all(16.0),
         children: [
           Text(
-            'يمكن للمحاسب هنا مراجعة واعتماد طلبات المبيعات ومتابعة التقارير المالية.',
+            appLocalizations.accountingOverview,
             style: const TextStyle(fontSize: 16),
             textAlign: TextAlign.center,
             textDirection: TextDirection.rtl,

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -423,7 +423,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
       modules.add(_buildModuleButton(
         context: context,
         title: appLocalizations.reports,
-        subtitle: "التقارير والتحليلات",
+        subtitle: appLocalizations.reports,
         icon: Icons.bar_chart,
         color: moduleColors['reports']!,
         onPressed: () => Navigator.of(context).pushNamed(AppRouter.reportsRoute),
@@ -1065,7 +1065,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                 ),
                 _buildDrawerItem(
                   icon: Icons.analytics_rounded,
-                  title: "التقارير والتحليلات",
+                  title: appLocalizations.reports,
                   onTap: () {
                     Navigator.pop(context);
                     // TODO: Navigate to reports


### PR DESCRIPTION
## Summary
- reference translations for reports module subtitles
- translate finance unit description and budget review option
- update localization files with new keys

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68651e9b58d8832a912af63fdb1ed562