### PR TITLE
Improve ProcurementScreen UI

### DIFF
--- a/lib/presentation/management/procurement_screen.dart
+++ b/lib/presentation/management/procurement_screen.dart
@@ -5,6 +5,7 @@ import 'package:plastic_factory_management/l10n/app_localizations.dart';
 import 'package:plastic_factory_management/data/models/purchase_request_model.dart';
 import 'package:plastic_factory_management/data/models/user_model.dart';
 import 'package:plastic_factory_management/domain/usecases/procurement_usecases.dart';
+import 'package:plastic_factory_management/theme/app_colors.dart';
 
 class ProcurementScreen extends StatelessWidget {
   const ProcurementScreen({super.key});
@@ -19,12 +20,16 @@ class ProcurementScreen extends StatelessWidget {
       appBar: AppBar(
         title: Text(appLocalizations.procurement),
         centerTitle: true,
+        backgroundColor: Theme.of(context).primaryColor,
+        foregroundColor: Colors.white,
+        elevation: 0,
         actions: [
           IconButton(
-            icon: const Icon(Icons.add),
+            icon: const Icon(Icons.add_box_outlined),
             onPressed: currentUser == null
                 ? null
                 : () => _showAddDialog(context, useCases, currentUser, appLocalizations),
+            tooltip: appLocalizations.addPurchaseRequest,
           ),
         ],
       ),
@@ -36,28 +41,87 @@ class ProcurementScreen extends StatelessWidget {
           }
           final requests = snapshot.data ?? [];
           if (requests.isEmpty) {
-            return Center(child: Text(appLocalizations.noData));
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.playlist_add_check_circle_outlined, size: 80, color: Colors.grey[400]),
+                  const SizedBox(height: 16),
+                  Text(appLocalizations.noData, style: TextStyle(color: Colors.grey[600], fontSize: 18)),
+                ],
+              ),
+            );
           }
           return ListView.builder(
             itemCount: requests.length,
             itemBuilder: (context, index) {
               final r = requests[index];
               return Card(
-                margin: const EdgeInsets.all(8),
-                child: ListTile(
-                  title: Text(
-                    '${r.requesterName} - ${intl.DateFormat.yMd().format(r.createdAt.toDate())}',
-                    textDirection: TextDirection.rtl,
+                margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                elevation: 1,
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                child: InkWell(
+                  onTap: () => _showRequestDialog(context, r, useCases, currentUser, appLocalizations),
+                  borderRadius: BorderRadius.circular(12),
+                  child: Padding(
+                    padding: const EdgeInsets.all(12.0),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: [
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Row(
+                              textDirection: TextDirection.rtl,
+                              children: [
+                                const Icon(Icons.person_outline, color: AppColors.primary, size: 28),
+                                const SizedBox(width: 8),
+                                Text(
+                                  r.requesterName,
+                                  style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+                                ),
+                              ],
+                            ),
+                            Container(
+                              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                              decoration: BoxDecoration(
+                                color: _getStatusColor(r.status).withOpacity(0.15),
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              child: Text(
+                                _statusToArabic(r.status, context),
+                                style: TextStyle(
+                                  color: _getStatusColor(r.status),
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 14,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        const Divider(height: 16),
+                        _buildInfoRow(appLocalizations.orderDate,
+                            intl.DateFormat('yyyy-MM-dd').format(r.createdAt.toDate()),
+                            icon: Icons.calendar_today_outlined),
+                        _buildInfoRow(appLocalizations.items, r.items.length.toString(), icon: Icons.list_alt),
+                      ],
+                    ),
                   ),
-                  subtitle: Text(r.status.name, textDirection: TextDirection.rtl),
-                  onTap: () =>
-                      _showRequestDialog(context, r, useCases, currentUser, appLocalizations),
                 ),
               );
             },
           );
         },
       ),
+      floatingActionButton: currentUser == null
+          ? null
+          : FloatingActionButton(
+              onPressed: () => _showAddDialog(context, useCases, currentUser, appLocalizations),
+              backgroundColor: AppColors.primary,
+              foregroundColor: Colors.white,
+              tooltip: appLocalizations.addPurchaseRequest,
+              child: const Icon(Icons.add),
+            ),
     );
   }
 
@@ -68,30 +132,41 @@ class ProcurementScreen extends StatelessWidget {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
         title: Text(appLocalizations.addPurchaseRequest, textAlign: TextAlign.center),
         content: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
             TextField(
               controller: descController,
-              decoration: InputDecoration(labelText: appLocalizations.description),
+              decoration: InputDecoration(
+                labelText: appLocalizations.description,
+                border: const OutlineInputBorder(),
+                prefixIcon: const Icon(Icons.description_outlined),
+              ),
               textDirection: TextDirection.rtl,
             ),
             const SizedBox(height: 8),
             TextField(
               controller: qtyController,
-              decoration: InputDecoration(labelText: appLocalizations.quantity),
+              decoration: InputDecoration(
+                labelText: appLocalizations.quantity,
+                border: const OutlineInputBorder(),
+                prefixIcon: const Icon(Icons.confirmation_num_outlined),
+              ),
               keyboardType: TextInputType.number,
               textDirection: TextDirection.rtl,
             ),
           ],
         ),
+        actionsAlignment: MainAxisAlignment.spaceAround,
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context),
             child: Text(appLocalizations.cancel),
+            style: TextButton.styleFrom(foregroundColor: Colors.grey[700]),
           ),
-          ElevatedButton(
+          ElevatedButton.icon(
             onPressed: () async {
               final quantity = int.tryParse(qtyController.text) ?? 1;
               final item = PurchaseRequestItem(
@@ -111,7 +186,13 @@ class ProcurementScreen extends StatelessWidget {
               await useCases.createPurchaseRequest(request);
               Navigator.pop(context);
             },
-            child: Text(appLocalizations.save),
+            icon: const Icon(Icons.save, color: Colors.white),
+            label: Text(appLocalizations.save),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppColors.primary,
+              foregroundColor: Colors.white,
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+            ),
           ),
         ],
       ),
@@ -127,40 +208,105 @@ class ProcurementScreen extends StatelessWidget {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
         title: Text(appLocalizations.purchaseRequests, textAlign: TextAlign.center),
         content: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            ...request.items
-                .map((e) => Text('${e.itemName} x${e.quantity}', textDirection: TextDirection.rtl)),
+            ...request.items.map((e) => Text('${e.itemName} x${e.quantity}', textDirection: TextDirection.rtl)),
             const SizedBox(height: 8),
-            Text(appLocalizations.statusColon + request.status.name,
-                textDirection: TextDirection.rtl),
+            Text('${appLocalizations.statusColon}${_statusToArabic(request.status, context)}', textDirection: TextDirection.rtl),
           ],
         ),
+        actionsAlignment: MainAxisAlignment.spaceAround,
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context),
             child: Text(appLocalizations.cancel),
+            style: TextButton.styleFrom(foregroundColor: Colors.grey[700]),
           ),
           if (user != null && request.status == PurchaseRequestStatus.pendingInventory)
-            TextButton(
+            ElevatedButton.icon(
               onPressed: () async {
-                await useCases.sendToSupplier(request,
-                    supplierId: 'default', supplierName: 'default');
+                await useCases.sendToSupplier(request, supplierId: 'default', supplierName: 'default');
                 Navigator.pop(context);
               },
-              child: Text(appLocalizations.sendToSuppliers),
+              icon: const Icon(Icons.local_shipping_outlined, color: Colors.white, size: 20),
+              label: Text(appLocalizations.sendToSuppliers),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.secondary,
+                foregroundColor: Colors.white,
+              ),
             ),
           if (user != null && request.status == PurchaseRequestStatus.awaitingFinance)
-            TextButton(
+            ElevatedButton.icon(
               onPressed: () async {
                 await useCases.approveFinance(request, user.uid, user.name);
                 Navigator.pop(context);
               },
-              child: Text(appLocalizations.financialApproval),
+              icon: const Icon(Icons.check_circle_outline, color: Colors.white, size: 20),
+              label: Text(appLocalizations.financialApproval),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.green.shade700,
+                foregroundColor: Colors.white,
+              ),
             ),
+        ],
+      ),
+    );
+  }
+
+  String _statusToArabic(PurchaseRequestStatus status, BuildContext context) {
+    switch (status) {
+      case PurchaseRequestStatus.pendingInventory:
+        return AppLocalizations.of(context)!.inventoryReview;
+      case PurchaseRequestStatus.awaitingSupplier:
+        return 'بانتظار المورد';
+      case PurchaseRequestStatus.awaitingFinance:
+        return 'مراجعة المالية';
+      case PurchaseRequestStatus.completed:
+        return 'مكتمل';
+    }
+  }
+
+  Color _getStatusColor(PurchaseRequestStatus status) {
+    switch (status) {
+      case PurchaseRequestStatus.pendingInventory:
+        return AppColors.accentOrange;
+      case PurchaseRequestStatus.awaitingSupplier:
+        return Colors.blue.shade700;
+      case PurchaseRequestStatus.awaitingFinance:
+        return AppColors.secondary;
+      case PurchaseRequestStatus.completed:
+        return Colors.green.shade700;
+    }
+  }
+
+  Widget _buildInfoRow(String label, String value, {IconData? icon}) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          if (icon != null) ...[
+            Icon(icon, size: 20, color: AppColors.primary.withOpacity(0.7)),
+            const SizedBox(width: 8),
+          ],
+          Text(
+            '$label:',
+            style: const TextStyle(fontSize: 15, fontWeight: FontWeight.bold),
+            textDirection: TextDirection.rtl,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              value,
+              style: const TextStyle(fontSize: 15, color: Colors.black87),
+              textDirection: TextDirection.rtl,
+              textAlign: TextAlign.left,
+            ),
+          ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- revamp ProcurementScreen with themed colors and icons
- show status badges and info rows
- enhance dialogs for adding and reviewing purchase requests

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653076df9c832a9998519e1cc77762