### PR TITLE
Fix disappearing maintenance schedule when checklist items checked

### DIFF
--- a/lib/data/datasources/maintenance_datasource.dart
+++ b/lib/data/datasources/maintenance_datasource.dart
@@ -16,7 +16,7 @@ class MaintenanceDatasource {
   }
 
   Stream<List<MaintenanceLogModel>> getScheduledMaintenance({String? machineId, String? responsibleUid}) {
-    Query query = _firestore.collection('maintenance_logs').where('status', isEqualTo: 'scheduled');
+    Query query = _firestore.collection('maintenance_logs').where('status', whereIn: ['scheduled', 'in_progress']);
     if (machineId != null) {
       query = query.where('machineId', isEqualTo: machineId);
     }


### PR DESCRIPTION
## Summary
- fix scheduled maintenance query to include `in_progress` status

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653514d82c832aa0add6994443a5f5