### PR TITLE
Update quick login roles

### DIFF
--- a/lib/presentation/auth/login_screen.dart
+++ b/lib/presentation/auth/login_screen.dart
@@ -118,29 +118,11 @@ class _LoginScreenState extends State<LoginScreen> with TickerProviderStateMixin
       'name': 'مسؤول العمليات',
       'icon': '📋',
     },
-    UserRole.productionOrderPreparer: {
-      'email': 'preparer@example.com',
-      'password': 'password',
-      'name': 'مسؤول إعداد طلبات الإنتاج',
-      'icon': '📝',
-    },
-    UserRole.moldInstallationSupervisor: {
-      'email': 'moldsupervisor@example.com',
-      'password': 'password',
-      'name': 'مشرف تركيب القوالب',
-      'icon': '🔧',
-    },
     UserRole.productionShiftSupervisor: {
       'email': 'shiftsupervisor@example.com',
       'password': 'password',
       'name': 'مشرف الوردية',
       'icon': '⏰',
-    },
-    UserRole.machineOperator: {
-      'email': 'operator@example.com',
-      'password': 'password',
-      'name': 'مشغل الآلة',
-      'icon': '⚙️',
     },
     UserRole.maintenanceManager: {
       'email': 'maintenance@example.com',


### PR DESCRIPTION
## Summary
- remove production preparer, mold supervisor and machine operator roles from quick login

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686581ea85c8832aa264fb8424c49631