### PR TITLE
Add approval notes to sales orders

### DIFF
--- a/lib/data/models/sales_order_model.dart
+++ b/lib/data/models/sales_order_model.dart
@@ -103,6 +103,7 @@ class SalesOrderModel {
   final String? approvedByUid; // UID المحاسب الذي اعتمد الطلب
   final String? approvedByName; // اسم المحاسب الذي اعتمد الطلب
   final Timestamp? approvedAt; // وقت الاعتماد
+  final String? approvalNotes; // ملاحظات الاعتماد من المحاسب
   final String? rejectionReason; // سبب الرفض إن وجد
   final bool moldTasksEnabled; // هل تم تفعيل مهام تركيب القوالب
   final String? moldSupervisorUid; // UID مشرف التركيب الذي اعتمد الطلب
@@ -136,6 +137,7 @@ class SalesOrderModel {
     this.approvedByUid,
     this.approvedByName,
     this.approvedAt,
+    this.approvalNotes,
     this.rejectionReason,
     this.moldTasksEnabled = false,
     this.moldSupervisorUid,
@@ -175,6 +177,7 @@ class SalesOrderModel {
       approvedByUid: data['approvedByUid'],
       approvedByName: data['approvedByName'],
       approvedAt: data['approvedAt'],
+      approvalNotes: data['approvalNotes'],
       rejectionReason: data['rejectionReason'],
       moldTasksEnabled: data['moldTasksEnabled'] ?? false,
       moldSupervisorUid: data['moldSupervisorUid'],
@@ -212,6 +215,7 @@ class SalesOrderModel {
       'approvedByUid': approvedByUid,
       'approvedByName': approvedByName,
       'approvedAt': approvedAt,
+      'approvalNotes': approvalNotes,
       'rejectionReason': rejectionReason,
       'moldTasksEnabled': moldTasksEnabled,
       'moldSupervisorUid': moldSupervisorUid,
@@ -247,6 +251,7 @@ class SalesOrderModel {
     String? approvedByUid,
     String? approvedByName,
     Timestamp? approvedAt,
+    String? approvalNotes,
     String? rejectionReason,
     bool? moldTasksEnabled,
     String? moldSupervisorUid,
@@ -280,6 +285,7 @@ class SalesOrderModel {
       approvedByUid: approvedByUid ?? this.approvedByUid,
       approvedByName: approvedByName ?? this.approvedByName,
       approvedAt: approvedAt ?? this.approvedAt,
+      approvalNotes: approvalNotes ?? this.approvalNotes,
       rejectionReason: rejectionReason ?? this.rejectionReason,
       moldTasksEnabled: moldTasksEnabled ?? this.moldTasksEnabled,
       moldSupervisorUid: moldSupervisorUid ?? this.moldSupervisorUid,

--- a/lib/domain/usecases/sales_usecases.dart
+++ b/lib/domain/usecases/sales_usecases.dart
@@ -135,7 +135,7 @@ class SalesUseCases {
   }
 
   // Accountant approves a sales order
-  Future<void> approveSalesOrder(SalesOrderModel order, UserModel accountant) async {
+  Future<void> approveSalesOrder(SalesOrderModel order, UserModel accountant, {String? notes}) async {
     final customer = await repository.getCustomerById(order.customerId);
     if (customer != null) {
       final newDebt = customer.currentDebt + order.totalAmount;
@@ -150,6 +150,7 @@ class SalesUseCases {
       approvedByUid: accountant.uid,
       approvedByName: accountant.name,
       approvedAt: Timestamp.now(),
+      approvalNotes: notes,
       rejectionReason: null,
       moldTasksEnabled: false,
     );

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -335,6 +335,8 @@
   ,"orderFlowDetails": "تفاصيل الإعتمادات"
   ,"approvedBy": "اعتمد بواسطة"
   ,"approvalTime": "وقت الاعتماد"
+  ,"approvalNotes": "ملاحظات الاعتماد"
+  ,"enterApprovalNotes": "أدخل ملاحظات الاعتماد"
   ,"moldInstallationTasks": "مهام تركيب القوالب"
   ,"noMoldInstallationOrders": "لا توجد طلبات بانتظار تركيب القوالب",
   "loginRequiredToViewOrders": "تسجيل الدخول مطلوب لعرض الطلبات.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -375,6 +375,8 @@
   "orderFlowDetails": "Approval Details",
   "approvedBy": "Approved By",
   "approvalTime": "Approval Time",
+  "approvalNotes": "Approval Notes",
+  "enterApprovalNotes": "Enter approval notes",
   "moldInstallationTasks": "Mold Installation Tasks",
   "noMoldInstallationOrders": "No orders awaiting mold installation",
   "loginRequiredToViewOrders": "Login required to view orders.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -305,6 +305,8 @@ class AppLocalizations {
   String get orderFlowDetails => _strings["orderFlowDetails"] ?? "orderFlowDetails";
   String get approvedBy => _strings["approvedBy"] ?? "approvedBy";
   String get approvalTime => _strings["approvalTime"] ?? "approvalTime";
+  String get approvalNotes => _strings["approvalNotes"] ?? "approvalNotes";
+  String get enterApprovalNotes => _strings["enterApprovalNotes"] ?? "enterApprovalNotes";
   String get moldInstallationTasks => _strings["moldInstallationTasks"] ?? "moldInstallationTasks";
   String get noMoldInstallationOrders => _strings["noMoldInstallationOrders"] ?? "noMoldInstallationOrders";
   String get loadingData => _strings["loadingData"] ?? "loadingData";

--- a/lib/presentation/sales/sales_order_detail_page.dart
+++ b/lib/presentation/sales/sales_order_detail_page.dart
@@ -87,6 +87,10 @@ class _SalesOrderDetailPageState extends State<SalesOrderDetailPage> {
                   '${intl.DateFormat('yyyy-MM-dd HH:mm').format(widget.order.approvedAt!.toDate())} ${appLocalizations.approvedBy} ${widget.order.approvedByName ?? appLocalizations.unknown}',
                   icon: Icons.check_circle_outline,
                 ),
+              if (widget.order.approvalNotes != null && widget.order.approvalNotes!.isNotEmpty)
+                _buildInfoRow(appLocalizations.approvalNotes, widget.order.approvalNotes!, icon: Icons.notes),
+              if (widget.order.rejectionReason != null && widget.order.rejectionReason!.isNotEmpty)
+                _buildInfoRow(appLocalizations.rejectionReason, widget.order.rejectionReason!, icon: Icons.cancel, textColor: Colors.red),
               if (widget.order.warehouseManagerName != null && widget.order.warehouseManagerName!.isNotEmpty)
                 _buildInfoRow(appLocalizations.warehouseManager, widget.order.warehouseManagerName!, icon: Icons.warehouse),
               if (widget.order.warehouseNotes != null && widget.order.warehouseNotes!.isNotEmpty)

--- a/lib/presentation/sales/sales_orders_list_screen.dart
+++ b/lib/presentation/sales/sales_orders_list_screen.dart
@@ -683,6 +683,7 @@ class _SalesOrdersListScreenState extends State<SalesOrdersListScreen> {
 
   void _showApproveDialog(BuildContext context, SalesUseCases useCases,
       AppLocalizations appLocalizations, SalesOrderModel order) {
+    final TextEditingController notesController = TextEditingController();
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
@@ -762,6 +763,18 @@ class _SalesOrdersListScreenState extends State<SalesOrdersListScreen> {
                   ),
                 ),
               const SizedBox(height: 16),
+              TextField(
+                controller: notesController,
+                decoration: InputDecoration(
+                  labelText: appLocalizations.enterApprovalNotes,
+                  border: const OutlineInputBorder(),
+                  prefixIcon: const Icon(Icons.notes_outlined),
+                ),
+                maxLines: 3,
+                textAlign: TextAlign.right,
+                textDirection: TextDirection.rtl,
+              ),
+              const SizedBox(height: 16),
               Text('${appLocalizations.confirmApproveOrderQuestion}: "${order.customerName}"؟', // More explicit question
                   textAlign: TextAlign.center, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
             ],
@@ -788,7 +801,13 @@ class _SalesOrdersListScreenState extends State<SalesOrdersListScreen> {
               );
               try {
                 final user = Provider.of<UserModel?>(context, listen: false)!;
-                await useCases.approveSalesOrder(order, user);
+                await useCases.approveSalesOrder(
+                  order,
+                  user,
+                  notes: notesController.text.trim().isEmpty
+                      ? null
+                      : notesController.text.trim(),
+                );
                 Navigator.of(context).pop(); // Pop the loading indicator
                 ScaffoldMessenger.of(context).showSnackBar(
                   SnackBar(


### PR DESCRIPTION
## Summary
- support storing approval notes in `SalesOrderModel`
- save optional notes when accountant approves orders
- display approval notes and rejection reasons in order details
- expose new localization strings for approval notes
- allow entering notes in the approval dialog

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868e94afad4832a8ee1d5fb55b9e7d7