### PR TITLE
Fix null check crash when approving sales order

### DIFF
--- a/lib/presentation/sales/sales_orders_list_screen.dart
+++ b/lib/presentation/sales/sales_orders_list_screen.dart
@@ -800,7 +800,15 @@ class _SalesOrdersListScreenState extends State<SalesOrdersListScreen> {
                 },
               );
               try {
-                final user = Provider.of<UserModel?>(context, listen: false)!;
+                final user = Provider.of<UserModel?>(context, listen: false);
+                if (user == null) {
+                  Navigator.of(context).pop(); // Pop the loading indicator
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text(appLocalizations.loginPrompt)),
+                  );
+                  return;
+                }
+
                 await useCases.approveSalesOrder(
                   order,
                   user,


### PR DESCRIPTION
## Summary
- prevent a crash when approving a sales order if the user data isn't available

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868ec6a4188832ab76c738548430141