### PR TITLE
Fix AlertDialog layout crash

### DIFF
--- a/lib/presentation/sales/sales_orders_list_screen.dart
+++ b/lib/presentation/sales/sales_orders_list_screen.dart
@@ -741,7 +741,8 @@ class _SalesOrdersListScreenState extends State<SalesOrdersListScreen> {
                         child: Image.network(
                           order.customerSignatureUrl!,
                           height: 100,
-                          width: double.infinity,
+                          // Avoid using double.infinity which causes layout issues
+                          // inside the IntrinsicWidth of AlertDialog
                           fit: BoxFit.contain,
                           loadingBuilder: (context, child, loadingProgress) {
                             if (loadingProgress == null) return child;


### PR DESCRIPTION
## Summary
- remove usage of `double.infinity` for signature image width

## Testing
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868fae0adac832abd1e6804d32b78ad