### PR TITLE
Add notes option when initiating warehouse supply

### DIFF
--- a/lib/domain/usecases/sales_usecases.dart
+++ b/lib/domain/usecases/sales_usecases.dart
@@ -215,11 +215,16 @@ class SalesUseCases {
 
   // Production order preparer initiates supply to warehouse
   Future<void> initiateSupply(
-      SalesOrderModel order, UserModel preparer, UserModel storekeeper) async {
+      SalesOrderModel order,
+      UserModel preparer,
+      UserModel storekeeper, {
+      String? notes,
+    }) async {
     final updated = order.copyWith(
       status: SalesOrderStatus.warehouseProcessing,
       warehouseManagerUid: storekeeper.uid,
       warehouseManagerName: storekeeper.name,
+      warehouseNotes: notes ?? order.warehouseNotes,
     );
     await repository.updateSalesOrder(updated);
 

--- a/lib/presentation/sales/sales_orders_list_screen.dart
+++ b/lib/presentation/sales/sales_orders_list_screen.dart
@@ -931,6 +931,8 @@ class _SalesOrdersListScreenState extends State<SalesOrdersListScreen> {
     }
     // Pre-select the first storekeeper if available, otherwise null
     UserModel? _selectedStorekeeper = storekeepers.isNotEmpty ? storekeepers.first : null;
+    final TextEditingController notesController =
+        TextEditingController(text: order.warehouseNotes);
 
     await showDialog(
       context: parentContext,
@@ -957,6 +959,18 @@ class _SalesOrdersListScreenState extends State<SalesOrdersListScreen> {
                   _selectedStorekeeper = u;
                 }),
                 validator: (value) => value == null ? appLocalizations.fieldRequired : null, // Added validation
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: notesController,
+                decoration: InputDecoration(
+                  labelText: appLocalizations.enterNotes,
+                  border: const OutlineInputBorder(),
+                  prefixIcon: const Icon(Icons.notes_outlined),
+                ),
+                maxLines: 3,
+                textAlign: TextAlign.right,
+                textDirection: TextDirection.rtl,
               ),
             ],
           ),
@@ -986,7 +1000,12 @@ class _SalesOrdersListScreenState extends State<SalesOrdersListScreen> {
                   },
                 );
                 try {
-                  await salesUseCases.initiateSupply(order, preparer, _selectedStorekeeper!);
+                  await salesUseCases.initiateSupply(
+                    order,
+                    preparer,
+                    _selectedStorekeeper!,
+                    notes: notesController.text.trim(),
+                  );
                   Navigator.of(parentContext).pop(); // Pop the loading indicator
                   ScaffoldMessenger.of(parentContext).showSnackBar(
                     SnackBar(content: Text(appLocalizations.supplyInitiatedSuccessfully)), // New confirmation


### PR DESCRIPTION
## Summary
- let `initiateSupply` accept optional notes
- allow entering notes in the initiate supply dialog and pass them to the use case

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869031b8ed8832a935a3643ec95eec4