### PR TITLE
Display role notes in order details

### DIFF
--- a/lib/data/models/sales_order_model.dart
+++ b/lib/data/models/sales_order_model.dart
@@ -111,6 +111,7 @@ class SalesOrderModel {
   final Timestamp? moldSupervisorApprovedAt; // وقت اعتماد المشرف
   final String? moldInstallationNotes; // ملاحظات عملية التركيب
   final List<String> moldInstallationImages; // صور توثيقية للتركيب
+  final String? operationsNotes; // ملاحظات مسؤول العمليات
   final String? warehouseNotes; // ملاحظات أمين المخزن
   final List<String> warehouseImages; // صور توثيق المخزن
   final String? warehouseManagerUid; // UID أمين المخزن المسؤول
@@ -145,6 +146,7 @@ class SalesOrderModel {
     this.moldSupervisorApprovedAt,
     this.moldInstallationNotes,
     this.moldInstallationImages = const [],
+    this.operationsNotes,
     this.warehouseNotes,
     this.warehouseImages = const [],
     this.warehouseManagerUid,
@@ -185,6 +187,7 @@ class SalesOrderModel {
       moldSupervisorApprovedAt: data['moldSupervisorApprovedAt'],
       moldInstallationNotes: data['moldInstallationNotes'],
       moldInstallationImages: List<String>.from(data['moldInstallationImages'] ?? []),
+      operationsNotes: data['operationsNotes'],
       warehouseNotes: data['warehouseNotes'],
       warehouseImages: List<String>.from(data['warehouseImages'] ?? []),
       warehouseManagerUid: data['warehouseManagerUid'],
@@ -223,6 +226,7 @@ class SalesOrderModel {
       'moldSupervisorApprovedAt': moldSupervisorApprovedAt,
       'moldInstallationNotes': moldInstallationNotes,
       'moldInstallationImages': moldInstallationImages,
+      'operationsNotes': operationsNotes,
       'warehouseNotes': warehouseNotes,
       'warehouseImages': warehouseImages,
       'warehouseManagerUid': warehouseManagerUid,
@@ -259,6 +263,7 @@ class SalesOrderModel {
     Timestamp? moldSupervisorApprovedAt,
     String? moldInstallationNotes,
     List<String>? moldInstallationImages,
+    String? operationsNotes,
     String? warehouseNotes,
     List<String>? warehouseImages,
     String? warehouseManagerUid,
@@ -293,6 +298,7 @@ class SalesOrderModel {
       moldSupervisorApprovedAt: moldSupervisorApprovedAt ?? this.moldSupervisorApprovedAt,
       moldInstallationNotes: moldInstallationNotes ?? this.moldInstallationNotes,
       moldInstallationImages: moldInstallationImages ?? this.moldInstallationImages,
+      operationsNotes: operationsNotes ?? this.operationsNotes,
       warehouseNotes: warehouseNotes ?? this.warehouseNotes,
       warehouseImages: warehouseImages ?? this.warehouseImages,
       warehouseManagerUid: warehouseManagerUid ?? this.warehouseManagerUid,

--- a/lib/domain/usecases/sales_usecases.dart
+++ b/lib/domain/usecases/sales_usecases.dart
@@ -224,7 +224,7 @@ class SalesUseCases {
       status: SalesOrderStatus.warehouseProcessing,
       warehouseManagerUid: storekeeper.uid,
       warehouseManagerName: storekeeper.name,
-      warehouseNotes: notes ?? order.warehouseNotes,
+      operationsNotes: notes ?? order.operationsNotes,
     );
     await repository.updateSalesOrder(updated);
 

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -329,6 +329,7 @@
   "orderApprovedTitle": "تم اعتماد طلب الإنتاج",
   "orderApprovedMessage": "تم تعيينك للمرحلة التالية"
   ,"warehouseNotes": "ملاحظات المخزن"
+  ,"operationsNotes": "ملاحظات العمليات"
   ,"warehouseImages": "صور المخزن"
   ,"moldInstallationNotes": "ملاحظات تركيب القوالب"
   ,"moldInstallationImages": "صور تركيب القوالب"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -369,6 +369,7 @@
   "orderApprovedTitle": "Production order approved",
   "orderApprovedMessage": "You have been assigned to the next stage",
   "warehouseNotes": "Warehouse Notes",
+  "operationsNotes": "Operations Notes",
   "warehouseImages": "Warehouse Images",
   "moldInstallationNotes": "Mold Installation Notes",
   "moldInstallationImages": "Mold Installation Images",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -299,6 +299,7 @@ class AppLocalizations {
   String get notifications => _strings["notifications"] ?? "notifications";
   String get noNotifications => _strings["noNotifications"] ?? "noNotifications";
   String get warehouseNotes => _strings["warehouseNotes"] ?? "warehouseNotes";
+  String get operationsNotes => _strings["operationsNotes"] ?? "operationsNotes";
   String get warehouseImages => _strings["warehouseImages"] ?? "warehouseImages";
   String get moldInstallationNotes => _strings["moldInstallationNotes"] ?? "moldInstallationNotes";
   String get moldInstallationImages => _strings["moldInstallationImages"] ?? "moldInstallationImages";

--- a/lib/presentation/sales/sales_order_detail_page.dart
+++ b/lib/presentation/sales/sales_order_detail_page.dart
@@ -89,6 +89,8 @@ class _SalesOrderDetailPageState extends State<SalesOrderDetailPage> {
                 ),
               if (widget.order.approvalNotes != null && widget.order.approvalNotes!.isNotEmpty)
                 _buildInfoRow(appLocalizations.approvalNotes, widget.order.approvalNotes!, icon: Icons.notes),
+              if (widget.order.operationsNotes != null && widget.order.operationsNotes!.isNotEmpty)
+                _buildInfoRow(appLocalizations.operationsNotes, widget.order.operationsNotes!, icon: Icons.notes),
               if (widget.order.rejectionReason != null && widget.order.rejectionReason!.isNotEmpty)
                 _buildInfoRow(appLocalizations.rejectionReason, widget.order.rejectionReason!, icon: Icons.cancel, textColor: Colors.red),
               if (widget.order.warehouseManagerName != null && widget.order.warehouseManagerName!.isNotEmpty)


### PR DESCRIPTION
## Summary
- add `operationsNotes` field to `SalesOrderModel`
- persist operations notes in Firestore
- show operations notes on the sales order detail page
- update localization files with Operations Notes key
- use operations notes when assigning supply

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68690437dd90832a812d59b47b878200