### PR TITLE
Integrate factory elements with inventory

### DIFF
--- a/lib/data/datasources/factory_element_datasource.dart
+++ b/lib/data/datasources/factory_element_datasource.dart
@@ -1,0 +1,29 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/factory_element_model.dart';
+
+class FactoryElementDatasource {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+
+  Stream<List<FactoryElementModel>> getElements() {
+    return _firestore.collection('factory_elements').snapshots().map((snapshot) {
+      return snapshot.docs
+          .map((doc) => FactoryElementModel.fromDocumentSnapshot(doc))
+          .toList();
+    });
+  }
+
+  Future<void> addElement(FactoryElementModel element) async {
+    await _firestore.collection('factory_elements').add(element.toMap());
+  }
+
+  Future<void> updateElement(FactoryElementModel element) async {
+    await _firestore
+        .collection('factory_elements')
+        .doc(element.id)
+        .update(element.toMap());
+  }
+
+  Future<void> deleteElement(String id) async {
+    await _firestore.collection('factory_elements').doc(id).delete();
+  }
+}

--- a/lib/data/repositories/factory_element_repository_impl.dart
+++ b/lib/data/repositories/factory_element_repository_impl.dart
@@ -1,0 +1,28 @@
+import '../datasources/factory_element_datasource.dart';
+import '../models/factory_element_model.dart';
+import '../../domain/repositories/factory_element_repository.dart';
+
+class FactoryElementRepositoryImpl implements FactoryElementRepository {
+  final FactoryElementDatasource datasource;
+  FactoryElementRepositoryImpl(this.datasource);
+
+  @override
+  Stream<List<FactoryElementModel>> getElements() {
+    return datasource.getElements();
+  }
+
+  @override
+  Future<void> addElement(FactoryElementModel element) {
+    return datasource.addElement(element);
+  }
+
+  @override
+  Future<void> updateElement(FactoryElementModel element) {
+    return datasource.updateElement(element);
+  }
+
+  @override
+  Future<void> deleteElement(String id) {
+    return datasource.deleteElement(id);
+  }
+}

--- a/lib/domain/repositories/factory_element_repository.dart
+++ b/lib/domain/repositories/factory_element_repository.dart
@@ -1,0 +1,8 @@
+import '../../data/models/factory_element_model.dart';
+
+abstract class FactoryElementRepository {
+  Stream<List<FactoryElementModel>> getElements();
+  Future<void> addElement(FactoryElementModel element);
+  Future<void> updateElement(FactoryElementModel element);
+  Future<void> deleteElement(String id);
+}

--- a/lib/domain/usecases/factory_element_usecases.dart
+++ b/lib/domain/usecases/factory_element_usecases.dart
@@ -1,0 +1,30 @@
+import '../../data/models/factory_element_model.dart';
+import '../repositories/factory_element_repository.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class FactoryElementUseCases {
+  final FactoryElementRepository repository;
+  FactoryElementUseCases(this.repository);
+
+  Stream<List<FactoryElementModel>> getElements() {
+    return repository.getElements();
+  }
+
+  Future<void> addElement({required String type, required String name}) {
+    final element = FactoryElementModel(
+      id: '',
+      type: type,
+      name: name,
+    );
+    return repository.addElement(element);
+  }
+
+  Future<void> updateElement({required String id, required String type, required String name}) {
+    final element = FactoryElementModel(id: id, type: type, name: name);
+    return repository.updateElement(element);
+  }
+
+  Future<void> deleteElement(String id) {
+    return repository.deleteElement(id);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,6 +26,9 @@ import 'package:plastic_factory_management/domain/usecases/production_order_usec
 import 'package:plastic_factory_management/data/datasources/inventory_datasource.dart';
 import 'package:plastic_factory_management/data/repositories/inventory_repository_impl.dart';
 import 'package:plastic_factory_management/domain/usecases/inventory_usecases.dart';
+import 'package:plastic_factory_management/data/datasources/factory_element_datasource.dart';
+import 'package:plastic_factory_management/data/repositories/factory_element_repository_impl.dart';
+import 'package:plastic_factory_management/domain/usecases/factory_element_usecases.dart';
 
 // استيرادات Machinery & Operator
 import 'package:plastic_factory_management/data/datasources/machinery_operator_datasource.dart';
@@ -146,6 +149,20 @@ class MyApp extends StatelessWidget {
             Provider.of<InventoryRepositoryImpl>(context, listen: false),
             Provider.of<NotificationUseCases>(context, listen: false),
             Provider.of<UserUseCases>(context, listen: false),
+          ),
+        ),
+        // توفير Factory Elements Dependencies
+        Provider<FactoryElementDatasource>(
+          create: (_) => FactoryElementDatasource(),
+        ),
+        Provider<FactoryElementRepositoryImpl>(
+          create: (context) => FactoryElementRepositoryImpl(
+            Provider.of<FactoryElementDatasource>(context, listen: false),
+          ),
+        ),
+        Provider<FactoryElementUseCases>(
+          create: (context) => FactoryElementUseCases(
+            Provider.of<FactoryElementRepositoryImpl>(context, listen: false),
           ),
         ),
         // توفير Production Order Dependencies


### PR DESCRIPTION
## Summary
- add datasource, repository and usecases for factory elements
- wire factory element providers in `main.dart`
- update Factory Elements screen to fetch from Firestore
- update Inventory Adjustment to select types and items from factory elements

## Testing
- `dart format lib` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b8a82c718832a9f6a0ba8ebe0981c