### PR TITLE
Fix undefined elementUseCases in InventoryAdjustmentScreen

### DIFF
--- a/lib/presentation/inventory/inventory_adjustment_screen.dart
+++ b/lib/presentation/inventory/inventory_adjustment_screen.dart
@@ -29,6 +29,7 @@ class _InventoryAdjustmentScreenState extends State<InventoryAdjustmentScreen> {
   Widget build(BuildContext context) {
     final appLocalizations = AppLocalizations.of(context)!;
     final useCases = Provider.of<InventoryUseCases>(context);
+    final elementUseCases = Provider.of<FactoryElementUseCases>(context);
     return Scaffold(
       appBar: AppBar(
         title: Text(appLocalizations.addInventoryEntry),


### PR DESCRIPTION
## Summary
- inject `FactoryElementUseCases` from `Provider` in `InventoryAdjustmentScreen`

## Testing
- `flutter format lib/presentation/inventory/inventory_adjustment_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b8cadb62c832a8b39b1da59a30cac