### PR TITLE
Add unit selection to factory elements

### DIFF
--- a/lib/data/models/factory_element_model.dart
+++ b/lib/data/models/factory_element_model.dart
@@ -4,11 +4,13 @@ class FactoryElementModel {
   final String id;
   final String type;
   final String name;
+  final String? unit; // Optional unit for raw materials
 
   FactoryElementModel({
     required this.id,
     required this.type,
     required this.name,
+    this.unit,
   });
 
   factory FactoryElementModel.fromDocumentSnapshot(DocumentSnapshot doc) {
@@ -17,6 +19,7 @@ class FactoryElementModel {
       id: doc.id,
       type: data['type'] ?? '',
       name: data['name'] ?? '',
+      unit: data['unit'] as String?,
     );
   }
 
@@ -24,14 +27,16 @@ class FactoryElementModel {
     return {
       'type': type,
       'name': name,
+      if (unit != null) 'unit': unit,
     };
   }
 
-  FactoryElementModel copyWith({String? id, String? type, String? name}) {
+  FactoryElementModel copyWith({String? id, String? type, String? name, String? unit}) {
     return FactoryElementModel(
       id: id ?? this.id,
       type: type ?? this.type,
       name: name ?? this.name,
+      unit: unit ?? this.unit,
     );
   }
 }

--- a/lib/domain/usecases/factory_element_usecases.dart
+++ b/lib/domain/usecases/factory_element_usecases.dart
@@ -10,17 +10,28 @@ class FactoryElementUseCases {
     return repository.getElements();
   }
 
-  Future<void> addElement({required String type, required String name}) {
+  Future<void> addElement({required String type, required String name, String? unit}) {
     final element = FactoryElementModel(
       id: '',
       type: type,
       name: name,
+      unit: unit,
     );
     return repository.addElement(element);
   }
 
-  Future<void> updateElement({required String id, required String type, required String name}) {
-    final element = FactoryElementModel(id: id, type: type, name: name);
+  Future<void> updateElement({
+    required String id,
+    required String type,
+    required String name,
+    String? unit,
+  }) {
+    final element = FactoryElementModel(
+      id: id,
+      type: type,
+      name: name,
+      unit: unit,
+    );
     return repository.updateElement(element);
   }
 

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -445,6 +445,7 @@
   "addInventoryItem": "إضافة صنف مخزون",
   "selectInventoryType": "اختر نوع المخزون",
   "selectItem": "اختر المنتج/العنصر",
+  "selectUnit": "اختر الوحدة",
   "finishedProducts": "الإنتاج التام",
   "spareParts": "قطع الغيار",
   "noData": "لا توجد بيانات",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -454,6 +454,7 @@
   "addInventoryItem": "إضافة صنف مخزون",
   "selectInventoryType": "اختر نوع المخزون",
   "selectItem": "اختر المنتج/العنصر",
+  "selectUnit": "اختر الوحدة",
   "finishedProducts": "Finished Products",
   "spareParts": "Spare Parts",
   "noData": "No data",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -437,6 +437,7 @@ class AppLocalizations {
   String get addInventoryItem => _strings["addInventoryItem"] ?? "addInventoryItem";
   String get selectInventoryType => _strings["selectInventoryType"] ?? "selectInventoryType";
   String get selectItem => _strings["selectItem"] ?? "selectItem";
+  String get selectUnit => _strings["selectUnit"] ?? "selectUnit";
   String get finishedProducts => _strings["finishedProducts"] ?? "finishedProducts";
   String get spareParts => _strings["spareParts"] ?? "spareParts";
   String get noData => _strings["noData"] ?? "noData";

--- a/lib/presentation/inventory/factory_elements_screen.dart
+++ b/lib/presentation/inventory/factory_elements_screen.dart
@@ -15,6 +15,7 @@ class FactoryElementsScreen extends StatefulWidget {
 
 class _FactoryElementsScreenState extends State<FactoryElementsScreen> {
   String _selectedType = 'all';
+  final List<String> _units = ['kg', 'liter', 'piece'];
 
   FactoryElementType _typeFromArabic(String type) {
     switch (type) {
@@ -54,6 +55,7 @@ class _FactoryElementsScreenState extends State<FactoryElementsScreen> {
     final customTypeController = TextEditingController(
       text: type == FactoryElementType.custom ? element.type : '',
     );
+    String? unit = element.unit;
     showDialog(
       context: context,
       builder: (context) {
@@ -107,6 +109,21 @@ class _FactoryElementsScreenState extends State<FactoryElementsScreen> {
                       labelText: AppLocalizations.of(context)!.elementName),
                   textDirection: TextDirection.rtl,
                 ),
+                if (type == FactoryElementType.rawMaterial) ...[
+                  const SizedBox(height: 12),
+                  DropdownButtonFormField<String>(
+                    value: unit,
+                    decoration: InputDecoration(
+                        labelText: AppLocalizations.of(context)!.selectUnit),
+                    items: _units
+                        .map((u) => DropdownMenuItem(
+                              value: u,
+                              child: Text(u, textDirection: TextDirection.rtl),
+                            ))
+                        .toList(),
+                    onChanged: (val) => setState(() => unit = val),
+                  ),
+                ],
               ],
             ),
           ),
@@ -125,7 +142,10 @@ class _FactoryElementsScreenState extends State<FactoryElementsScreen> {
                 final useCases =
                     Provider.of<FactoryElementUseCases>(context, listen: false);
                 useCases.updateElement(
-                    id: element.id, type: finalType, name: name);
+                    id: element.id,
+                    type: finalType,
+                    name: name,
+                    unit: unit);
                 Navigator.pop(context);
               },
               child: Text(AppLocalizations.of(context)!.save),
@@ -140,6 +160,7 @@ class _FactoryElementsScreenState extends State<FactoryElementsScreen> {
     FactoryElementType type = FactoryElementType.rawMaterial;
     final nameController = TextEditingController();
     final customTypeController = TextEditingController();
+    String? unit = _units.first;
     showDialog(
       context: context,
       builder: (context) {
@@ -193,6 +214,21 @@ class _FactoryElementsScreenState extends State<FactoryElementsScreen> {
                       labelText: AppLocalizations.of(context)!.elementName),
                   textDirection: TextDirection.rtl,
                 ),
+                if (type == FactoryElementType.rawMaterial) ...[
+                  const SizedBox(height: 12),
+                  DropdownButtonFormField<String>(
+                    value: unit,
+                    decoration: InputDecoration(
+                        labelText: AppLocalizations.of(context)!.selectUnit),
+                    items: _units
+                        .map((u) => DropdownMenuItem(
+                              value: u,
+                              child: Text(u, textDirection: TextDirection.rtl),
+                            ))
+                        .toList(),
+                    onChanged: (val) => setState(() => unit = val),
+                  ),
+                ],
               ],
             ),
           ),
@@ -210,7 +246,7 @@ class _FactoryElementsScreenState extends State<FactoryElementsScreen> {
                 if (name.isEmpty || finalType.isEmpty) return;
                 final useCases =
                     Provider.of<FactoryElementUseCases>(context, listen: false);
-                useCases.addElement(type: finalType, name: name);
+                useCases.addElement(type: finalType, name: name, unit: unit);
                 Navigator.pop(context);
               },
               child: Text(AppLocalizations.of(context)!.add),
@@ -288,7 +324,10 @@ class _FactoryElementsScreenState extends State<FactoryElementsScreen> {
                           title: Text(element.name,
                               textDirection: TextDirection.rtl,
                               textAlign: TextAlign.right),
-                          subtitle: Text(element.type,
+                          subtitle: Text(
+                              element.unit != null && element.unit!.isNotEmpty
+                                  ? '${element.type} - ${element.unit}'
+                                  : element.type,
                               textDirection: TextDirection.rtl,
                               textAlign: TextAlign.right),
                           trailing: Row(


### PR DESCRIPTION
## Summary
- extend `FactoryElementModel` with optional unit field
- allow unit selection when adding or editing raw material elements
- show unit in factory elements list
- update translations and localization getters

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b9c76a654832a921155db95e8f2a9