### PR TITLE
Enable color and production input selection for templates

### DIFF
--- a/lib/data/models/template_model.dart
+++ b/lib/data/models/template_model.dart
@@ -31,6 +31,7 @@ class TemplateModel {
   final double costPerHour; // تكلفة الساعة للقالب
   final List<TemplateMaterial> materialsUsed; // المواد المستخدمة
   final List<String> colors; // الألوان
+  final List<String> productionInputs; // مدخلات الإنتاج
 
   TemplateModel({
     required this.id,
@@ -40,6 +41,7 @@ class TemplateModel {
     required this.costPerHour,
     required this.materialsUsed,
     required this.colors,
+    required this.productionInputs,
   });
 
   factory TemplateModel.fromDocumentSnapshot(DocumentSnapshot doc) {
@@ -55,6 +57,7 @@ class TemplateModel {
               .toList() ??
           [],
       colors: List<String>.from(data['colors'] ?? []),
+      productionInputs: List<String>.from(data['productionInputs'] ?? []),
     );
   }
 
@@ -66,6 +69,7 @@ class TemplateModel {
       'costPerHour': costPerHour,
       'materialsUsed': materialsUsed.map((e) => e.toMap()).toList(),
       'colors': colors,
+      'productionInputs': productionInputs,
     };
   }
 
@@ -77,6 +81,7 @@ class TemplateModel {
     double? costPerHour,
     List<TemplateMaterial>? materialsUsed,
     List<String>? colors,
+    List<String>? productionInputs,
   }) {
     return TemplateModel(
       id: id ?? this.id,
@@ -86,6 +91,7 @@ class TemplateModel {
       costPerHour: costPerHour ?? this.costPerHour,
       materialsUsed: materialsUsed ?? this.materialsUsed,
       colors: colors ?? this.colors,
+      productionInputs: productionInputs ?? this.productionInputs,
     );
   }
 

--- a/lib/domain/usecases/inventory_usecases.dart
+++ b/lib/domain/usecases/inventory_usecases.dart
@@ -73,6 +73,7 @@ class InventoryUseCases {
     required double costPerHour,
     required List<TemplateMaterial> materialsUsed,
     required List<String> colors,
+    required List<String> productionInputs,
   }) async {
     final newTemplate = TemplateModel(
       id: '',
@@ -82,6 +83,7 @@ class InventoryUseCases {
       costPerHour: costPerHour,
       materialsUsed: materialsUsed,
       colors: colors,
+      productionInputs: productionInputs,
     );
     await repository.addTemplate(newTemplate);
   }
@@ -94,6 +96,7 @@ class InventoryUseCases {
     required double costPerHour,
     required List<TemplateMaterial> materialsUsed,
     required List<String> colors,
+    required List<String> productionInputs,
   }) async {
     final updated = TemplateModel(
       id: id,
@@ -103,6 +106,7 @@ class InventoryUseCases {
       costPerHour: costPerHour,
       materialsUsed: materialsUsed,
       colors: colors,
+      productionInputs: productionInputs,
     );
     await repository.updateTemplate(updated);
   }

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -59,6 +59,7 @@
   "productCode": "رقم الكود",
   "materialsUsed": "المواد المستخدمة لإنتاجه",
   "colors": "الألوان",
+  "productionInputs": "مدخلات إنتاج",
   "additives": "إضافات",
   "templates": "القوالب",
   "addTemplate": "إضافة قالب",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -96,6 +96,7 @@
   "productCode": "رقم الكود",
   "materialsUsed": "المواد المستخدمة لإنتاجه",
   "colors": "الألوان",
+  "productionInputs": "مدخلات إنتاج",
   "additives": "إضافات",
   "templates": "القوالب",
   "addTemplate": "إضافة قالب",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -76,6 +76,7 @@ class AppLocalizations {
   String get productCode => _strings["productCode"] ?? "productCode";
   String get materialsUsed => _strings["materialsUsed"] ?? "materialsUsed";
   String get colors => _strings["colors"] ?? "colors";
+  String get productionInputs => _strings["productionInputs"] ?? "productionInputs";
   String get additives => _strings["additives"] ?? "additives";
   String get templates => _strings["templates"] ?? "templates";
   String get selectTemplate => _strings["selectTemplate"] ?? "selectTemplate";


### PR DESCRIPTION
## Summary
- extend `TemplateModel` with `productionInputs`
- allow adding colors and production inputs from factory elements when editing/creating templates
- save the new lists through `InventoryUseCases`
- add translations and localization support for production inputs

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_686ba0ecedd4832ab1f967990fc36aa5