### PR TITLE
Display codes in item dropdowns

### DIFF
--- a/lib/presentation/accounting/purchases_screen.dart
+++ b/lib/presentation/accounting/purchases_screen.dart
@@ -476,9 +476,9 @@ class PurchasesScreen extends StatelessWidget {
   }
 
   String _getName(dynamic item) {
-    if (item is RawMaterialModel) return item.name;
-    if (item is ProductModel) return item.name;
-    if (item is SparePartModel) return item.name;
+    if (item is RawMaterialModel) return '${item.code} - ${item.name}';
+    if (item is ProductModel) return '${item.productCode} - ${item.name}';
+    if (item is SparePartModel) return '${item.code} - ${item.name}';
     return '';
   }
 

--- a/lib/presentation/management/procurement_screen.dart
+++ b/lib/presentation/management/procurement_screen.dart
@@ -395,9 +395,9 @@ class ProcurementScreen extends StatelessWidget {
   }
 
   String _getName(dynamic item) {
-    if (item is RawMaterialModel) return item.name;
-    if (item is ProductModel) return item.name;
-    if (item is SparePartModel) return item.name;
+    if (item is RawMaterialModel) return '${item.code} - ${item.name}';
+    if (item is ProductModel) return '${item.productCode} - ${item.name}';
+    if (item is SparePartModel) return '${item.code} - ${item.name}';
     return '';
   }
 }


### PR DESCRIPTION
## Summary
- show item code alongside the name when selecting an item for purchases and purchase requests

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ba55f54dc832aac3e10626e49724b