### PR TITLE
Add accountant approval workflow

### DIFF
--- a/lib/data/models/purchase_request_model.dart
+++ b/lib/data/models/purchase_request_model.dart
@@ -1,10 +1,10 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 enum PurchaseRequestStatus {
-  pendingInventory,
-  awaitingSupplier,
-  awaitingFinance,
-  completed,
+  awaitingApproval, // بانتظار اعتماد المحاسب
+  awaitingWarehouse, // بانتظار أمين المخزن
+  completed, // تم استلام المشتريات
+  rejected, // مرفوض من المحاسب
 }
 
 extension PurchaseRequestStatusExtension on PurchaseRequestStatus {
@@ -12,7 +12,7 @@ extension PurchaseRequestStatusExtension on PurchaseRequestStatus {
   static PurchaseRequestStatus fromString(String status) {
     return PurchaseRequestStatus.values.firstWhere(
       (e) => e.name == status,
-      orElse: () => PurchaseRequestStatus.pendingInventory,
+      orElse: () => PurchaseRequestStatus.awaitingApproval,
     );
   }
 }
@@ -54,9 +54,12 @@ class PurchaseRequestModel {
   final Timestamp createdAt;
   final String? supplierId;
   final String? supplierName;
-  final String? financeUid;
-  final String? financeName;
-  final Timestamp? financeApprovedAt;
+  final String? accountantUid;
+  final String? accountantName;
+  final Timestamp? accountantApprovedAt;
+  final String? warehouseUid;
+  final String? warehouseName;
+  final Timestamp? warehouseReceivedAt;
 
   PurchaseRequestModel({
     required this.id,
@@ -68,9 +71,12 @@ class PurchaseRequestModel {
     required this.createdAt,
     this.supplierId,
     this.supplierName,
-    this.financeUid,
-    this.financeName,
-    this.financeApprovedAt,
+    this.accountantUid,
+    this.accountantName,
+    this.accountantApprovedAt,
+    this.warehouseUid,
+    this.warehouseName,
+    this.warehouseReceivedAt,
   });
 
   factory PurchaseRequestModel.fromDocumentSnapshot(DocumentSnapshot doc) {
@@ -84,13 +90,16 @@ class PurchaseRequestModel {
               .toList() ??
           [],
       totalAmount: (data['totalAmount'] as num?)?.toDouble() ?? 0.0,
-      status: PurchaseRequestStatusExtension.fromString(data['status'] ?? 'pendingInventory'),
+      status: PurchaseRequestStatusExtension.fromString(data['status'] ?? 'awaitingApproval'),
       createdAt: data['createdAt'] ?? Timestamp.now(),
       supplierId: data['supplierId'],
       supplierName: data['supplierName'],
-      financeUid: data['financeUid'],
-      financeName: data['financeName'],
-      financeApprovedAt: data['financeApprovedAt'],
+      accountantUid: data['accountantUid'],
+      accountantName: data['accountantName'],
+      accountantApprovedAt: data['accountantApprovedAt'],
+      warehouseUid: data['warehouseUid'],
+      warehouseName: data['warehouseName'],
+      warehouseReceivedAt: data['warehouseReceivedAt'],
     );
   }
 
@@ -104,9 +113,12 @@ class PurchaseRequestModel {
       'createdAt': createdAt,
       'supplierId': supplierId,
       'supplierName': supplierName,
-      'financeUid': financeUid,
-      'financeName': financeName,
-      'financeApprovedAt': financeApprovedAt,
+      'accountantUid': accountantUid,
+      'accountantName': accountantName,
+      'accountantApprovedAt': accountantApprovedAt,
+      'warehouseUid': warehouseUid,
+      'warehouseName': warehouseName,
+      'warehouseReceivedAt': warehouseReceivedAt,
     };
   }
 
@@ -120,9 +132,12 @@ class PurchaseRequestModel {
     Timestamp? createdAt,
     String? supplierId,
     String? supplierName,
-    String? financeUid,
-    String? financeName,
-    Timestamp? financeApprovedAt,
+    String? accountantUid,
+    String? accountantName,
+    Timestamp? accountantApprovedAt,
+    String? warehouseUid,
+    String? warehouseName,
+    Timestamp? warehouseReceivedAt,
   }) {
     return PurchaseRequestModel(
       id: id ?? this.id,
@@ -134,9 +149,12 @@ class PurchaseRequestModel {
       createdAt: createdAt ?? this.createdAt,
       supplierId: supplierId ?? this.supplierId,
       supplierName: supplierName ?? this.supplierName,
-      financeUid: financeUid ?? this.financeUid,
-      financeName: financeName ?? this.financeName,
-      financeApprovedAt: financeApprovedAt ?? this.financeApprovedAt,
+      accountantUid: accountantUid ?? this.accountantUid,
+      accountantName: accountantName ?? this.accountantName,
+      accountantApprovedAt: accountantApprovedAt ?? this.accountantApprovedAt,
+      warehouseUid: warehouseUid ?? this.warehouseUid,
+      warehouseName: warehouseName ?? this.warehouseName,
+      warehouseReceivedAt: warehouseReceivedAt ?? this.warehouseReceivedAt,
     );
   }
 }

--- a/lib/domain/usecases/procurement_usecases.dart
+++ b/lib/domain/usecases/procurement_usecases.dart
@@ -17,23 +17,35 @@ class ProcurementUseCases {
     await repository.addPurchaseRequest(request);
   }
 
-  Future<void> sendToSupplier(PurchaseRequestModel request,
-      {required String supplierId, required String supplierName}) async {
+  Future<void> approveByAccountant(
+      PurchaseRequestModel request, String approverUid, String approverName) async {
     final updated = request.copyWith(
-      status: PurchaseRequestStatus.awaitingFinance,
-      supplierId: supplierId,
-      supplierName: supplierName,
+      status: PurchaseRequestStatus.awaitingWarehouse,
+      accountantUid: approverUid,
+      accountantName: approverName,
+      accountantApprovedAt: Timestamp.now(),
     );
     await repository.updatePurchaseRequest(updated);
   }
 
-  Future<void> approveFinance(
+  Future<void> rejectByAccountant(
       PurchaseRequestModel request, String approverUid, String approverName) async {
     final updated = request.copyWith(
+      status: PurchaseRequestStatus.rejected,
+      accountantUid: approverUid,
+      accountantName: approverName,
+      accountantApprovedAt: Timestamp.now(),
+    );
+    await repository.updatePurchaseRequest(updated);
+  }
+
+  Future<void> receiveByWarehouse(
+      PurchaseRequestModel request, String uid, String name) async {
+    final updated = request.copyWith(
       status: PurchaseRequestStatus.completed,
-      financeUid: approverUid,
-      financeName: approverName,
-      financeApprovedAt: Timestamp.now(),
+      warehouseUid: uid,
+      warehouseName: name,
+      warehouseReceivedAt: Timestamp.now(),
     );
     await repository.updatePurchaseRequest(updated);
   }

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -465,6 +465,8 @@
   "inventoryReview": "مراجعة المخزون",
   "sendToSuppliers": "إرسال للموردين",
   "financialApproval": "الموافقة المالية",
+  "awaitingApproval": "بانتظار اعتماد المحاسب",
+  "awaitingWarehouse": "بانتظار أمين المخزن",
   "recordPayment": "تسجيل دفعة",
   "addPurchase": "إضافة شراء",
   "selectCustomer": "اختر العميل",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -474,6 +474,8 @@
   "inventoryReview": "Inventory Review",
   "sendToSuppliers": "Send to Suppliers",
   "financialApproval": "Financial Approval",
+  "awaitingApproval": "Awaiting Accountant Approval",
+  "awaitingWarehouse": "Awaiting Warehouse",
   "recordPayment": "Record Payment",
   "addPurchase": "Add Purchase",
   "selectCustomer": "Select Customer",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -484,6 +484,8 @@ class AppLocalizations {
   String get inventoryReview => _strings["inventoryReview"] ?? "inventoryReview";
   String get sendToSuppliers => _strings["sendToSuppliers"] ?? "sendToSuppliers";
   String get financialApproval => _strings["financialApproval"] ?? "financialApproval";
+  String get awaitingApproval => _strings["awaitingApproval"] ?? "awaitingApproval";
+  String get awaitingWarehouse => _strings["awaitingWarehouse"] ?? "awaitingWarehouse";
   String get recordPayment => _strings["recordPayment"] ?? "recordPayment";
   String get addPurchase => _strings["addPurchase"] ?? "addPurchase";
   String get selectCustomer => _strings["selectCustomer"] ?? "selectCustomer";

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -757,6 +757,15 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
         color: moduleColors['inventory']!,
         onPressed: () => Navigator.of(context).pushNamed(AppRouter.productCatalogRoute),
       ));
+
+      modules.add(_buildModuleButton(
+        context: context,
+        title: appLocalizations.purchaseRequests,
+        subtitle: "طلبات المشتريات",
+        icon: Icons.shopping_bag,
+        color: moduleColors['procurement']!,
+        onPressed: () => Navigator.of(context).pushNamed(AppRouter.procurementRoute),
+      ));
     }
 
     // Modules for Quality Inspector (مراقب الجودة)
@@ -789,6 +798,15 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
         icon: Icons.shopping_cart,
         color: moduleColors['sales']!,
         onPressed: () => Navigator.of(context).pushNamed(AppRouter.salesOrdersListRoute),
+      ));
+
+      modules.add(_buildModuleButton(
+        context: context,
+        title: appLocalizations.purchaseRequests,
+        subtitle: "طلبات المشتريات",
+        icon: Icons.shopping_bag,
+        color: moduleColors['procurement']!,
+        onPressed: () => Navigator.of(context).pushNamed(AppRouter.procurementRoute),
       ));
     }
 


### PR DESCRIPTION
## Summary
- overhaul `PurchaseRequestStatus` values
- store accountant and warehouse approvals in `PurchaseRequestModel`
- update procurement use cases for approval/receiving
- adapt procurement screen UI for accountant and storekeeper
- expose purchase request management for accountant and inventory manager
- translate new status labels

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686ba705517c832a8d9ce746d0715781