### PR TITLE
Add machine selection when creating production order

### DIFF
--- a/lib/domain/usecases/production_order_usecases.dart
+++ b/lib/domain/usecases/production_order_usecases.dart
@@ -6,6 +6,7 @@ import 'package:plastic_factory_management/data/models/production_order_model.da
 import 'package:plastic_factory_management/data/models/product_model.dart';
 import 'package:plastic_factory_management/data/models/raw_material_model.dart';
 import 'package:plastic_factory_management/data/models/user_model.dart';
+import 'package:plastic_factory_management/data/models/machine_model.dart';
 import 'package:plastic_factory_management/data/models/sales_order_model.dart';
 import 'package:plastic_factory_management/data/models/inventory_balance_model.dart';
 import 'package:plastic_factory_management/data/repositories/production_order_repository.dart';
@@ -72,6 +73,7 @@ class ProductionOrderUseCases {
   Future<ProductionOrderModel> createProductionOrder({
     required ProductModel selectedProduct,
     required int requiredQuantity,
+    MachineModel? selectedMachine,
     required UserModel orderPreparer, // Pass the current user model
     String? salesOrderId,
   }) async {
@@ -102,10 +104,8 @@ class ProductionOrderUseCases {
       batchNumber: batchNumber,
       templateId: null,
       templateName: null,
-      machineId: null,
-      machineName: null,
-      salesOrderId: salesOrderId,
-      orderPreparerUid: orderPreparer.uid,
+      machineId: selectedMachine?.id,
+      machineName: selectedMachine?.name,
       orderPreparerName: orderPreparer.name,
       orderPreparerRole: orderPreparer.userRoleEnum.toFirestoreString(),
       status: ProductionOrderStatus.pending, // الحالة الإجمالية للطلب هي 'قيد الانتظار'


### PR DESCRIPTION
## Summary
- allow choosing a machine when creating a production order
- wire machine selection through use cases and UI

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686ba9d1be0c832ab08d770ebfb28225