### PR TITLE
Fix missing orderPreparerUid param

### DIFF
--- a/lib/domain/usecases/production_order_usecases.dart
+++ b/lib/domain/usecases/production_order_usecases.dart
@@ -106,6 +106,7 @@ class ProductionOrderUseCases {
       templateName: null,
       machineId: selectedMachine?.id,
       machineName: selectedMachine?.name,
+      orderPreparerUid: orderPreparer.uid,
       orderPreparerName: orderPreparer.name,
       orderPreparerRole: orderPreparer.userRoleEnum.toFirestoreString(),
       status: ProductionOrderStatus.pending, // الحالة الإجمالية للطلب هي 'قيد الانتظار'


### PR DESCRIPTION
## Summary
- include `orderPreparerUid` when creating production orders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686baf5602b0832aa66157d80a509980