### PR TITLE
Fix undefined isOperationsOfficer variable

### DIFF
--- a/lib/presentation/sales/sales_orders_list_screen.dart
+++ b/lib/presentation/sales/sales_orders_list_screen.dart
@@ -330,6 +330,7 @@ class _SalesOrdersListScreenState extends State<SalesOrdersListScreen> {
                                   isAccountant,
                                   isProductionOrderPreparer,
                                   isInventoryManager,
+                                  isOperationsOfficer,
                                   isMoldInstallationSupervisor,
                                 ),
                               ),
@@ -397,6 +398,7 @@ class _SalesOrdersListScreenState extends State<SalesOrdersListScreen> {
       bool isAccountant,
       bool isProductionOrderPreparer,
       bool isInventoryManager,
+      bool isOperationsOfficer,
       bool isMoldInstallationSupervisor) {
     List<Widget> actions = [];
 


### PR DESCRIPTION
## Summary
- add `isOperationsOfficer` param to trailing actions builder
- pass `isOperationsOfficer` from sales order list screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bb68c748c832ab8b30c14deb90f7f