### PR TITLE
Add quick login for mold supervisor role

### DIFF
--- a/lib/presentation/auth/login_screen.dart
+++ b/lib/presentation/auth/login_screen.dart
@@ -118,6 +118,12 @@ class _LoginScreenState extends State<LoginScreen> with TickerProviderStateMixin
       'name': 'مسؤول العمليات',
       'icon': '📋',
     },
+    UserRole.moldInstallationSupervisor: {
+      'email': 'mold@example.com',
+      'password': 'password',
+      'name': 'مشرف تركيب القوالب',
+      'icon': '🛠',
+    },
     UserRole.productionShiftSupervisor: {
       'email': 'shiftsupervisor@example.com',
       'password': 'password',


### PR DESCRIPTION
## Summary
- enable quick sign-in for `moldInstallationSupervisor` role on login screen

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bbac95660832a88aa99478b507c5b