### PR TITLE
Update machine status during maintenance

### DIFF
--- a/lib/domain/usecases/machinery_operator_usecases.dart
+++ b/lib/domain/usecases/machinery_operator_usecases.dart
@@ -64,6 +64,15 @@ class MachineryOperatorUseCases {
     return repository.getMachineById(machineId);
   }
 
+  // Update only the status of a machine
+  Future<void> updateMachineStatus(String machineId, MachineStatus status) async {
+    final machine = await repository.getMachineById(machineId);
+    if (machine != null) {
+      final updatedMachine = machine.copyWith(status: status);
+      await repository.updateMachine(updatedMachine);
+    }
+  }
+
   // --- Operator Use Cases ---
 
   Stream<List<OperatorModel>> getOperators() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -209,6 +209,7 @@ class MyApp extends StatelessWidget {
           create: (context) => MaintenanceUseCases(
             Provider.of<MaintenanceRepositoryImpl>(context, listen: false),
             Provider.of<InventoryUseCases>(context, listen: false),
+            Provider.of<MachineryOperatorUseCases>(context, listen: false),
           ),
         ),
         // توفير Sales Dependencies (جديد)


### PR DESCRIPTION
## Summary
- add helper `updateMachineStatus` to `MachineryOperatorUseCases`
- inject `MachineryOperatorUseCases` into `MaintenanceUseCases`
- set machine status to `underMaintenance` when scheduling a maintenance task
- return machine status to `ready` once maintenance is completed

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc94df3fc832abb3503761224385f