### PR TITLE
Implement order delivery on quality check

### DIFF
--- a/lib/domain/usecases/sales_usecases.dart
+++ b/lib/domain/usecases/sales_usecases.dart
@@ -134,6 +134,12 @@ class SalesUseCases {
     }
   }
 
+  // Mark a sales order as delivered (fulfilled)
+  Future<void> markOrderDelivered(SalesOrderModel order) async {
+    final updatedOrder = order.copyWith(status: SalesOrderStatus.fulfilled);
+    await repository.updateSalesOrder(updatedOrder);
+  }
+
   // Accountant approves a sales order
   Future<void> approveSalesOrder(SalesOrderModel order, UserModel accountant, {String? notes}) async {
     final customer = await repository.getCustomerById(order.customerId);

--- a/lib/presentation/quality/quality_check_form_screen.dart
+++ b/lib/presentation/quality/quality_check_form_screen.dart
@@ -112,6 +112,18 @@ class _QualityCheckFormScreenState extends State<QualityCheckFormScreen> {
       defectAnalysis: _defectController.text,
       imageUrls: urls,
     );
+
+    // Mark related orders as delivered
+    if (_salesOrder != null) {
+      final salesUseCases = Provider.of<SalesUseCases>(context, listen: false);
+      await salesUseCases.markOrderDelivered(_salesOrder!);
+    }
+    if (_productionOrder != null) {
+      final prodUseCases =
+          Provider.of<ProductionOrderUseCases>(context, listen: false);
+      await prodUseCases.markOrderDelivered(_productionOrder!, currentUser);
+    }
+
     if (mounted) Navigator.of(context).pop();
   }
 


### PR DESCRIPTION
## Summary
- add function to mark sales order delivered
- add function to mark production order delivered
- update quality check form to deliver linked orders automatically

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ce07221f4832a82eb77d49bee2d09