### PR TITLE
Add quality approval workflow

### DIFF
--- a/lib/core/constants/app_enums.dart
+++ b/lib/core/constants/app_enums.dart
@@ -171,3 +171,29 @@ extension FactoryElementTypeExtension on FactoryElementType {
     );
   }
 }
+
+enum OrderType { sales, production }
+
+extension OrderTypeExtension on OrderType {
+  String toFirestoreString() => name;
+
+  static OrderType fromString(String value) {
+    return OrderType.values.firstWhere(
+      (e) => e.name == value,
+      orElse: () => OrderType.sales,
+    );
+  }
+}
+
+enum QualityApprovalStatus { approved, rejected }
+
+extension QualityApprovalStatusExtension on QualityApprovalStatus {
+  String toFirestoreString() => name;
+
+  static QualityApprovalStatus fromString(String value) {
+    return QualityApprovalStatus.values.firstWhere(
+      (e) => e.name == value,
+      orElse: () => QualityApprovalStatus.approved,
+    );
+  }
+}

--- a/lib/data/models/quality_check_model.dart
+++ b/lib/data/models/quality_check_model.dart
@@ -1,24 +1,32 @@
 // plastic_factory_management/lib/data/models/quality_check_model.dart
 
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:plastic_factory_management/core/constants/app_enums.dart';
 
 class QualityCheckModel {
   final String id;
-  final String productId;
-  final String productName;
+  final String orderId;
+  final OrderType orderType;
+  final QualityApprovalStatus status;
+  final String? productId;
+  final String? productName;
   final int inspectedQuantity;
   final int rejectedQuantity;
   final int acceptedQuantity;
-  final String shiftSupervisorUid;
-  final String shiftSupervisorName;
+  final String? shiftSupervisorUid;
+  final String? shiftSupervisorName;
   final String qualityInspectorUid;
   final String qualityInspectorName;
+  final String? notes;
   final String? defectAnalysis;
   final List<String> imageUrls;
   final Timestamp createdAt;
 
   QualityCheckModel({
     required this.id,
+    required this.orderId,
+    required this.orderType,
+    required this.status,
     required this.productId,
     required this.productName,
     required this.inspectedQuantity,
@@ -28,6 +36,7 @@ class QualityCheckModel {
     required this.shiftSupervisorName,
     required this.qualityInspectorUid,
     required this.qualityInspectorName,
+    this.notes,
     this.defectAnalysis,
     this.imageUrls = const [],
     required this.createdAt,
@@ -37,15 +46,20 @@ class QualityCheckModel {
     final data = doc.data() as Map<String, dynamic>;
     return QualityCheckModel(
       id: doc.id,
-      productId: data['productId'] ?? '',
-      productName: data['productName'] ?? '',
+      orderId: data['orderId'] ?? '',
+      orderType: OrderTypeExtension.fromString(data['orderType'] ?? 'sales'),
+      status:
+          QualityApprovalStatusExtension.fromString(data['status'] ?? 'approved'),
+      productId: data['productId'],
+      productName: data['productName'],
       inspectedQuantity: data['inspectedQuantity'] ?? 0,
       rejectedQuantity: data['rejectedQuantity'] ?? 0,
       acceptedQuantity: data['acceptedQuantity'] ?? 0,
-      shiftSupervisorUid: data['shiftSupervisorUid'] ?? '',
-      shiftSupervisorName: data['shiftSupervisorName'] ?? '',
+      shiftSupervisorUid: data['shiftSupervisorUid'],
+      shiftSupervisorName: data['shiftSupervisorName'],
       qualityInspectorUid: data['qualityInspectorUid'] ?? '',
       qualityInspectorName: data['qualityInspectorName'] ?? '',
+      notes: data['notes'],
       defectAnalysis: data['defectAnalysis'],
       imageUrls: List<String>.from(data['imageUrls'] ?? []),
       createdAt: data['createdAt'] ?? Timestamp.now(),
@@ -54,6 +68,9 @@ class QualityCheckModel {
 
   Map<String, dynamic> toMap() {
     return {
+      'orderId': orderId,
+      'orderType': orderType.toFirestoreString(),
+      'status': status.toFirestoreString(),
       'productId': productId,
       'productName': productName,
       'inspectedQuantity': inspectedQuantity,
@@ -63,6 +80,7 @@ class QualityCheckModel {
       'shiftSupervisorName': shiftSupervisorName,
       'qualityInspectorUid': qualityInspectorUid,
       'qualityInspectorName': qualityInspectorName,
+      'notes': notes,
       'defectAnalysis': defectAnalysis,
       'imageUrls': imageUrls,
       'createdAt': createdAt,
@@ -71,6 +89,9 @@ class QualityCheckModel {
 
   QualityCheckModel copyWith({
     String? id,
+    String? orderId,
+    OrderType? orderType,
+    QualityApprovalStatus? status,
     String? productId,
     String? productName,
     int? inspectedQuantity,
@@ -80,12 +101,16 @@ class QualityCheckModel {
     String? shiftSupervisorName,
     String? qualityInspectorUid,
     String? qualityInspectorName,
+    String? notes,
     String? defectAnalysis,
     List<String>? imageUrls,
     Timestamp? createdAt,
   }) {
     return QualityCheckModel(
       id: id ?? this.id,
+      orderId: orderId ?? this.orderId,
+      orderType: orderType ?? this.orderType,
+      status: status ?? this.status,
       productId: productId ?? this.productId,
       productName: productName ?? this.productName,
       inspectedQuantity: inspectedQuantity ?? this.inspectedQuantity,
@@ -95,6 +120,7 @@ class QualityCheckModel {
       shiftSupervisorName: shiftSupervisorName ?? this.shiftSupervisorName,
       qualityInspectorUid: qualityInspectorUid ?? this.qualityInspectorUid,
       qualityInspectorName: qualityInspectorName ?? this.qualityInspectorName,
+      notes: notes ?? this.notes,
       defectAnalysis: defectAnalysis ?? this.defectAnalysis,
       imageUrls: imageUrls ?? this.imageUrls,
       createdAt: createdAt ?? this.createdAt,

--- a/lib/domain/usecases/quality_usecases.dart
+++ b/lib/domain/usecases/quality_usecases.dart
@@ -3,6 +3,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:plastic_factory_management/data/models/quality_check_model.dart';
 import 'package:plastic_factory_management/domain/repositories/quality_repository.dart';
+import 'package:plastic_factory_management/core/constants/app_enums.dart';
 
 class QualityUseCases {
   final QualityRepository repository;
@@ -13,19 +14,26 @@ class QualityUseCases {
   }
 
   Future<void> recordQualityCheck({
-    required String productId,
-    required String productName,
-    required int inspectedQuantity,
-    required int rejectedQuantity,
-    required String shiftSupervisorUid,
-    required String shiftSupervisorName,
+    required String orderId,
+    required OrderType orderType,
+    required QualityApprovalStatus status,
+    String? productId,
+    String? productName,
+    int inspectedQuantity = 0,
+    int rejectedQuantity = 0,
+    String? shiftSupervisorUid,
+    String? shiftSupervisorName,
     required String qualityInspectorUid,
     required String qualityInspectorName,
+    String? notes,
     String? defectAnalysis,
     List<String> imageUrls = const [],
   }) async {
     final check = QualityCheckModel(
       id: '',
+      orderId: orderId,
+      orderType: orderType,
+      status: status,
       productId: productId,
       productName: productName,
       inspectedQuantity: inspectedQuantity,
@@ -35,6 +43,7 @@ class QualityUseCases {
       shiftSupervisorName: shiftSupervisorName,
       qualityInspectorUid: qualityInspectorUid,
       qualityInspectorName: qualityInspectorName,
+      notes: notes,
       defectAnalysis: defectAnalysis,
       imageUrls: imageUrls,
       createdAt: Timestamp.now(),

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -397,7 +397,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
         subtitle: "فحص الجودة",
         icon: Icons.verified,
         color: moduleColors['quality']!,
-        onPressed: () => Navigator.of(context).pushNamed(AppRouter.qualityInspectionRoute),
+        onPressed: () => Navigator.of(context).pushNamed(AppRouter.qualityApprovalRoute),
       ));
 
       modules.add(_buildModuleButton(
@@ -774,7 +774,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
         subtitle: "فحص الجودة",
         icon: Icons.verified,
         color: moduleColors['quality']!,
-        onPressed: () => Navigator.of(context).pushNamed(AppRouter.qualityInspectionRoute),
+        onPressed: () => Navigator.of(context).pushNamed(AppRouter.qualityApprovalRoute),
       ));
     }
 

--- a/lib/presentation/quality/quality_approval_screen.dart
+++ b/lib/presentation/quality/quality_approval_screen.dart
@@ -1,0 +1,203 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../core/constants/app_enums.dart';
+import '../../data/models/production_order_model.dart';
+import '../../data/models/sales_order_model.dart';
+import '../../data/models/user_model.dart';
+import '../../domain/usecases/production_order_usecases.dart';
+import '../../domain/usecases/quality_usecases.dart';
+import '../../domain/usecases/sales_usecases.dart';
+import '../../l10n/app_localizations.dart';
+
+class QualityApprovalScreen extends StatefulWidget {
+  const QualityApprovalScreen({super.key});
+
+  @override
+  State<QualityApprovalScreen> createState() => _QualityApprovalScreenState();
+}
+
+class _QualityApprovalScreenState extends State<QualityApprovalScreen> {
+  final TextEditingController _orderIdController = TextEditingController();
+  final TextEditingController _notesController = TextEditingController();
+  OrderType? _orderType;
+  SalesOrderModel? _salesOrder;
+  ProductionOrderModel? _productionOrder;
+
+  @override
+  void dispose() {
+    _orderIdController.dispose();
+    _notesController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _fetchOrder() async {
+    final id = _orderIdController.text.trim();
+    if (id.isEmpty || _orderType == null) return;
+    if (_orderType == OrderType.sales) {
+      final salesUseCases = Provider.of<SalesUseCases>(context, listen: false);
+      final order = await salesUseCases.getSalesOrderById(id);
+      setState(() {
+        _salesOrder = order;
+        _productionOrder = null;
+      });
+    } else {
+      final prodUseCases =
+          Provider.of<ProductionOrderUseCases>(context, listen: false);
+      final order = await prodUseCases.getProductionOrderById(id);
+      setState(() {
+        _productionOrder = order;
+        _salesOrder = null;
+      });
+    }
+  }
+
+  Future<void> _submit(bool approved) async {
+    final id = _orderIdController.text.trim();
+    if (id.isEmpty || _orderType == null) return;
+    final currentUser = Provider.of<UserModel?>(context, listen: false);
+    if (currentUser == null) return;
+
+    final qualityUseCases = Provider.of<QualityUseCases>(context, listen: false);
+    await qualityUseCases.recordQualityCheck(
+      orderId: id,
+      orderType: _orderType!,
+      status:
+          approved ? QualityApprovalStatus.approved : QualityApprovalStatus.rejected,
+      qualityInspectorUid: currentUser.uid,
+      qualityInspectorName: currentUser.name,
+      notes: _notesController.text.trim().isEmpty
+          ? null
+          : _notesController.text.trim(),
+    );
+
+    if (approved) {
+      if (_salesOrder != null) {
+        final salesUseCases = Provider.of<SalesUseCases>(context, listen: false);
+        await salesUseCases.markOrderDelivered(_salesOrder!);
+      }
+      if (_productionOrder != null) {
+        final prodUseCases =
+            Provider.of<ProductionOrderUseCases>(context, listen: false);
+        await prodUseCases.markOrderDelivered(_productionOrder!, currentUser);
+      }
+    }
+
+    if (mounted) Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(loc.approveRejectOrder),
+        centerTitle: true,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              DropdownButtonFormField<OrderType>(
+                value: _orderType,
+                decoration: InputDecoration(labelText: loc.orderType),
+                items: [
+                  DropdownMenuItem(
+                    value: OrderType.sales,
+                    child: Text(loc.salesOrder),
+                  ),
+                  DropdownMenuItem(
+                    value: OrderType.production,
+                    child: Text(loc.productionOrder),
+                  ),
+                ],
+                onChanged: (val) => setState(() => _orderType = val),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _orderIdController,
+                decoration: InputDecoration(labelText: loc.orderId),
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: _fetchOrder,
+                child: Text(loc.fetchOrder),
+              ),
+              if (_salesOrder != null || _productionOrder != null) ...[
+                const SizedBox(height: 12),
+                _buildOrderDetails(loc),
+                const SizedBox(height: 12),
+              ],
+              TextField(
+                controller: _notesController,
+                decoration: InputDecoration(labelText: loc.approvalNotes),
+                maxLines: 3,
+              ),
+              const SizedBox(height: 24),
+              Row(
+                children: [
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: () => _submit(true),
+                      child: Text(loc.approve),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: () => _submit(false),
+                      style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+                      child: Text(loc.reject),
+                    ),
+                  ),
+                ],
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildOrderDetails(AppLocalizations loc) {
+    if (_salesOrder != null) {
+      final o = _salesOrder!;
+      return Card(
+        child: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('${loc.salesOrder} #${o.id}',
+                  style: const TextStyle(fontWeight: FontWeight.bold)),
+              Text('${loc.customerName}: ${o.customerName}'),
+              Text('${loc.statusColon} ${o.status.toArabicString()}'),
+            ],
+          ),
+        ),
+      );
+    }
+    if (_productionOrder != null) {
+      final o = _productionOrder!;
+      return Card(
+        child: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('${loc.productionOrder} #${o.id}',
+                  style: const TextStyle(fontWeight: FontWeight.bold)),
+              if (o.machineName != null)
+                Text('${loc.machineName}: ${o.machineName}'),
+              Text('${loc.productName}: ${o.productName}'),
+              Text('${loc.statusColon} ${o.status.toArabicString()}'),
+            ],
+          ),
+        ),
+      );
+    }
+    return const SizedBox.shrink();
+  }
+}

--- a/lib/presentation/quality/quality_check_form_screen.dart
+++ b/lib/presentation/quality/quality_check_form_screen.dart
@@ -16,8 +16,7 @@ import 'package:plastic_factory_management/domain/usecases/sales_usecases.dart';
 import 'package:plastic_factory_management/domain/usecases/production_order_usecases.dart';
 import 'package:plastic_factory_management/l10n/app_localizations.dart';
 import 'package:plastic_factory_management/core/services/file_upload_service.dart';
-
-enum OrderType { sales, production }
+import 'package:plastic_factory_management/core/constants/app_enums.dart';
 
 class QualityCheckFormScreen extends StatefulWidget {
   const QualityCheckFormScreen({Key? key}) : super(key: key);
@@ -101,6 +100,9 @@ class _QualityCheckFormScreenState extends State<QualityCheckFormScreen> {
 
     final useCases = Provider.of<QualityUseCases>(context, listen: false);
     await useCases.recordQualityCheck(
+      orderId: _orderIdController.text.trim(),
+      orderType: _orderType!,
+      status: QualityApprovalStatus.approved,
       productId: _selectedProduct!.id,
       productName: _selectedProduct!.name,
       inspectedQuantity: inspected,
@@ -109,6 +111,7 @@ class _QualityCheckFormScreenState extends State<QualityCheckFormScreen> {
       shiftSupervisorName: _supervisorController.text,
       qualityInspectorUid: currentUser.uid,
       qualityInspectorName: currentUser.name,
+      notes: null,
       defectAnalysis: _defectController.text,
       imageUrls: urls,
     );

--- a/lib/presentation/routes/app_router.dart
+++ b/lib/presentation/routes/app_router.dart
@@ -18,6 +18,7 @@ import 'package:plastic_factory_management/presentation/sales/customer_managemen
 import 'package:plastic_factory_management/presentation/sales/create_sales_order_screen.dart'; // استيراد جديد
 import 'package:plastic_factory_management/presentation/sales/sales_orders_list_screen.dart'; // استيراد جديد
 import 'package:plastic_factory_management/presentation/quality/quality_inspection_screen.dart';
+import 'package:plastic_factory_management/presentation/quality/quality_approval_screen.dart';
 import 'package:plastic_factory_management/presentation/inventory/inventory_management_screen.dart';
 import 'package:plastic_factory_management/presentation/inventory/inventory_adjustment_screen.dart';
 import 'package:plastic_factory_management/presentation/inventory/inventory_add_item_screen.dart';
@@ -56,6 +57,7 @@ class AppRouter {
   static const String createSalesOrderRoute = '/sales/orders/create'; // مسار جديد
   static const String salesOrdersListRoute = '/sales/orders/list'; // مسار جديد
   static const String qualityInspectionRoute = '/quality/inspections';
+  static const String qualityApprovalRoute = '/quality/approval';
   static const String inventoryManagementRoute = '/inventory/management';
   static const String inventoryAdjustmentRoute = '/inventory/adjustment';
   static const String inventoryAddItemRoute = '/inventory/add_item';
@@ -109,6 +111,8 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => SalesOrdersListScreen());
       case qualityInspectionRoute:
         return MaterialPageRoute(builder: (_) => QualityInspectionScreen());
+      case qualityApprovalRoute:
+        return MaterialPageRoute(builder: (_) => const QualityApprovalScreen());
       case inventoryManagementRoute:
         return MaterialPageRoute(builder: (_) => InventoryManagementScreen());
       case inventoryAdjustmentRoute:


### PR DESCRIPTION
## Summary
- add OrderType and QualityApprovalStatus enums
- extend `QualityCheckModel` to record approvals
- update `QualityUseCases.recordQualityCheck` signature
- add new `QualityApprovalScreen` and routing
- adjust home screen navigation and quality check form

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ce24f1498832ab877c6f114c44a2a