### PR TITLE
Add sales return request creation

### DIFF
--- a/lib/data/models/return_request_model.dart
+++ b/lib/data/models/return_request_model.dart
@@ -34,6 +34,7 @@ class ReturnRequestModel {
   final String id;
   final String requesterUid;
   final String requesterName;
+  final String salesOrderId;
   final String reason;
   final ReturnRequestStatus status;
   final Timestamp createdAt;
@@ -51,6 +52,7 @@ class ReturnRequestModel {
     required this.id,
     required this.requesterUid,
     required this.requesterName,
+    required this.salesOrderId,
     required this.reason,
     required this.status,
     required this.createdAt,
@@ -71,6 +73,7 @@ class ReturnRequestModel {
       id: doc.id,
       requesterUid: data['requesterUid'] ?? '',
       requesterName: data['requesterName'] ?? '',
+      salesOrderId: data['salesOrderId'] ?? '',
       reason: data['reason'] ?? '',
       status: ReturnRequestStatusExtension.fromString(data['status'] ?? 'pendingOperations'),
       createdAt: data['createdAt'] ?? Timestamp.now(),
@@ -90,6 +93,7 @@ class ReturnRequestModel {
     return {
       'requesterUid': requesterUid,
       'requesterName': requesterName,
+      'salesOrderId': salesOrderId,
       'reason': reason,
       'status': status.toFirestoreString(),
       'createdAt': createdAt,
@@ -109,6 +113,7 @@ class ReturnRequestModel {
     String? id,
     String? requesterUid,
     String? requesterName,
+    String? salesOrderId,
     String? reason,
     ReturnRequestStatus? status,
     Timestamp? createdAt,
@@ -126,6 +131,7 @@ class ReturnRequestModel {
       id: id ?? this.id,
       requesterUid: requesterUid ?? this.requesterUid,
       requesterName: requesterName ?? this.requesterName,
+      salesOrderId: salesOrderId ?? this.salesOrderId,
       reason: reason ?? this.reason,
       status: status ?? this.status,
       createdAt: createdAt ?? this.createdAt,

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -714,6 +714,15 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
         color: moduleColors['sales']!,
         onPressed: () => Navigator.of(context).pushNamed(AppRouter.salesOrdersListRoute),
       ));
+
+      modules.add(_buildModuleButton(
+        context: context,
+        title: appLocalizations.returnRequests,
+        subtitle: "طلبات المرتجع",
+        icon: Icons.assignment_return,
+        color: moduleColors['returns']!,
+        onPressed: () => Navigator.of(context).pushNamed(AppRouter.returnsRoute),
+      ));
     }
 
     // Modules for Inventory Manager (أمين المخزن)


### PR DESCRIPTION
## Summary
- extend `ReturnRequestModel` with `salesOrderId`
- allow sales reps to view returns module and add requests using order ID
- show related order info in return request dialogs

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cee25eb54832a9f376a3d9e87e924