### PR TITLE
Add machine selection when forwarding sales order

### DIFF
--- a/lib/data/models/sales_order_model.dart
+++ b/lib/data/models/sales_order_model.dart
@@ -112,6 +112,8 @@ class SalesOrderModel {
   final String? moldInstallationNotes; // ملاحظات عملية التركيب
   final List<String> moldInstallationImages; // صور توثيقية للتركيب
   final String? operationsNotes; // ملاحظات مسؤول العمليات
+  final String? machineId; // الآلة المحددة للطلب
+  final String? machineName; // اسم الآلة المحددة
   final String? warehouseNotes; // ملاحظات أمين المخزن
   final List<String> warehouseImages; // صور توثيق المخزن
   final String? warehouseManagerUid; // UID أمين المخزن المسؤول
@@ -147,6 +149,8 @@ class SalesOrderModel {
     this.moldInstallationNotes,
     this.moldInstallationImages = const [],
     this.operationsNotes,
+    this.machineId,
+    this.machineName,
     this.warehouseNotes,
     this.warehouseImages = const [],
     this.warehouseManagerUid,
@@ -188,6 +192,8 @@ class SalesOrderModel {
       moldInstallationNotes: data['moldInstallationNotes'],
       moldInstallationImages: List<String>.from(data['moldInstallationImages'] ?? []),
       operationsNotes: data['operationsNotes'],
+      machineId: data['machineId'],
+      machineName: data['machineName'],
       warehouseNotes: data['warehouseNotes'],
       warehouseImages: List<String>.from(data['warehouseImages'] ?? []),
       warehouseManagerUid: data['warehouseManagerUid'],
@@ -227,6 +233,8 @@ class SalesOrderModel {
       'moldInstallationNotes': moldInstallationNotes,
       'moldInstallationImages': moldInstallationImages,
       'operationsNotes': operationsNotes,
+      'machineId': machineId,
+      'machineName': machineName,
       'warehouseNotes': warehouseNotes,
       'warehouseImages': warehouseImages,
       'warehouseManagerUid': warehouseManagerUid,
@@ -264,6 +272,8 @@ class SalesOrderModel {
     String? moldInstallationNotes,
     List<String>? moldInstallationImages,
     String? operationsNotes,
+    String? machineId,
+    String? machineName,
     String? warehouseNotes,
     List<String>? warehouseImages,
     String? warehouseManagerUid,
@@ -299,6 +309,8 @@ class SalesOrderModel {
       moldInstallationNotes: moldInstallationNotes ?? this.moldInstallationNotes,
       moldInstallationImages: moldInstallationImages ?? this.moldInstallationImages,
       operationsNotes: operationsNotes ?? this.operationsNotes,
+      machineId: machineId ?? this.machineId,
+      machineName: machineName ?? this.machineName,
       warehouseNotes: warehouseNotes ?? this.warehouseNotes,
       warehouseImages: warehouseImages ?? this.warehouseImages,
       warehouseManagerUid: warehouseManagerUid ?? this.warehouseManagerUid,

--- a/lib/domain/usecases/sales_usecases.dart
+++ b/lib/domain/usecases/sales_usecases.dart
@@ -4,6 +4,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:plastic_factory_management/data/models/customer_model.dart';
 import 'package:plastic_factory_management/data/models/sales_order_model.dart';
 import 'package:plastic_factory_management/data/models/product_model.dart';
+import 'package:plastic_factory_management/data/models/machine_model.dart';
 import 'package:plastic_factory_management/data/models/user_model.dart';
 import 'package:plastic_factory_management/domain/repositories/sales_repository.dart';
 import 'dart:io';
@@ -274,11 +275,16 @@ class SalesUseCases {
 
   /// Operations officer forwards order to mold supervisor after review
   Future<void> forwardToMoldSupervisor(
-      SalesOrderModel order, UserModel operationsOfficer,
-      {String? notes}) async {
+      SalesOrderModel order,
+      UserModel operationsOfficer, {
+      String? notes,
+      MachineModel? machine,
+    }) async {
     final updated = order.copyWith(
       status: SalesOrderStatus.awaitingMoldApproval,
       operationsNotes: notes ?? order.operationsNotes,
+      machineId: machine?.id ?? order.machineId,
+      machineName: machine?.name ?? order.machineName,
     );
     await repository.updateSalesOrder(updated);
 

--- a/lib/presentation/sales/sales_order_detail_page.dart
+++ b/lib/presentation/sales/sales_order_detail_page.dart
@@ -91,6 +91,8 @@ class _SalesOrderDetailPageState extends State<SalesOrderDetailPage> {
                 _buildInfoRow(appLocalizations.approvalNotes, widget.order.approvalNotes!, icon: Icons.notes),
               if (widget.order.operationsNotes != null && widget.order.operationsNotes!.isNotEmpty)
                 _buildInfoRow(appLocalizations.operationsNotes, widget.order.operationsNotes!, icon: Icons.notes),
+              if (widget.order.machineName != null && widget.order.machineName!.isNotEmpty)
+                _buildInfoRow(appLocalizations.machine, widget.order.machineName!, icon: Icons.precision_manufacturing_outlined),
               if (widget.order.rejectionReason != null && widget.order.rejectionReason!.isNotEmpty)
                 _buildInfoRow(appLocalizations.rejectionReason, widget.order.rejectionReason!, icon: Icons.cancel, textColor: Colors.red),
               if (widget.order.warehouseManagerName != null && widget.order.warehouseManagerName!.isNotEmpty)


### PR DESCRIPTION
## Summary
- extend `SalesOrderModel` with `machineId` and `machineName`
- include machine selection in operations officer flow when forwarding to mold supervisor
- store selected machine in the order and show it in details

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cf198e8ac832a985b87388d77bd17