### PR TITLE
Add inventory validation for orders

### DIFF
--- a/lib/data/datasources/inventory_datasource.dart
+++ b/lib/data/datasources/inventory_datasource.dart
@@ -155,6 +155,20 @@ class InventoryDatasource {
             .toList());
   }
 
+  Future<InventoryBalanceModel?> getInventoryBalance(
+      String itemId, InventoryItemType type) async {
+    final query = await _firestore
+        .collection('inventory_balances')
+        .where('itemId', isEqualTo: itemId)
+        .where('type', isEqualTo: inventoryItemTypeToString(type))
+        .limit(1)
+        .get();
+    if (query.docs.isNotEmpty) {
+      return InventoryBalanceModel.fromDocumentSnapshot(query.docs.first);
+    }
+    return null;
+  }
+
   Future<void> updateInventoryQuantity({
     required String itemId,
     required InventoryItemType type,

--- a/lib/data/repositories/inventory_repository_impl.dart
+++ b/lib/data/repositories/inventory_repository_impl.dart
@@ -118,6 +118,12 @@ class InventoryRepositoryImpl implements InventoryRepository {
   }
 
   @override
+  Future<InventoryBalanceModel?> getInventoryBalance(
+      String itemId, InventoryItemType type) {
+    return datasource.getInventoryBalance(itemId, type);
+  }
+
+  @override
   Future<void> updateInventoryQuantity({
     required String itemId,
     required InventoryItemType type,

--- a/lib/domain/repositories/inventory_repository.dart
+++ b/lib/domain/repositories/inventory_repository.dart
@@ -37,6 +37,8 @@ abstract class InventoryRepository {
 
   // --- Inventory Balances ---
   Stream<List<InventoryBalanceModel>> getInventoryBalances(InventoryItemType type);
+  Future<InventoryBalanceModel?> getInventoryBalance(
+      String itemId, InventoryItemType type);
   Future<void> updateInventoryQuantity({
     required String itemId,
     required InventoryItemType type,

--- a/lib/domain/usecases/inventory_usecases.dart
+++ b/lib/domain/usecases/inventory_usecases.dart
@@ -258,6 +258,17 @@ class InventoryUseCases {
     return repository.getInventoryBalances(type);
   }
 
+  Future<InventoryBalanceModel?> getInventoryBalance(
+      String itemId, InventoryItemType type) {
+    return repository.getInventoryBalance(itemId, type);
+  }
+
+  Future<double> getAvailableQuantity(
+      String itemId, InventoryItemType type) async {
+    final balance = await repository.getInventoryBalance(itemId, type);
+    return balance?.quantity ?? 0;
+  }
+
   Future<void> adjustInventory({
     required String itemId,
     required InventoryItemType type,

--- a/lib/domain/usecases/procurement_usecases.dart
+++ b/lib/domain/usecases/procurement_usecases.dart
@@ -40,7 +40,8 @@ class ProcurementUseCases {
   }
 
   Future<void> receiveByWarehouse(
-      PurchaseRequestModel request, String uid, String name) async {
+      PurchaseRequestModel request, String uid, String name,
+      InventoryUseCases inventoryUseCases) async {
     final updated = request.copyWith(
       status: PurchaseRequestStatus.completed,
       warehouseUid: uid,
@@ -48,5 +49,14 @@ class ProcurementUseCases {
       warehouseReceivedAt: Timestamp.now(),
     );
     await repository.updatePurchaseRequest(updated);
+
+    for (final item in request.items) {
+      await inventoryUseCases.adjustInventoryWithNotification(
+        itemId: item.itemId,
+        itemName: item.itemName,
+        type: InventoryItemType.rawMaterial,
+        delta: item.quantity.toDouble(),
+      );
+    }
   }
 }

--- a/lib/domain/usecases/production_order_usecases.dart
+++ b/lib/domain/usecases/production_order_usecases.dart
@@ -77,6 +77,14 @@ class ProductionOrderUseCases {
     required UserModel orderPreparer, // Pass the current user model
     String? salesOrderId,
   }) async {
+    for (final material in selectedProduct.billOfMaterials) {
+      final needed = material.quantityPerUnit * requiredQuantity;
+      final available = await inventoryUseCases.getAvailableQuantity(
+          material.materialId, InventoryItemType.rawMaterial);
+      if (available < needed) {
+        throw Exception('INSUFFICIENT_STOCK');
+      }
+    }
     // Define the initial workflow stages
     final List<ProductionWorkflowStage> initialWorkflow = [
       ProductionWorkflowStage(

--- a/lib/domain/usecases/sales_usecases.dart
+++ b/lib/domain/usecases/sales_usecases.dart
@@ -97,7 +97,15 @@ class SalesUseCases {
     required double totalAmount,
     File? customerSignatureFile,
     Uint8List? customerSignatureBytes,
+    required InventoryUseCases inventoryUseCases,
   }) async {
+    for (final item in orderItems) {
+      final available = await inventoryUseCases.getAvailableQuantity(
+          item.productId, InventoryItemType.finishedProduct);
+      if (available < item.quantity) {
+        throw Exception('INSUFFICIENT_STOCK');
+      }
+    }
     final newOrder = SalesOrderModel(
       id: '', // Firestore will generate
       customerId: customer.id,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -318,6 +318,8 @@ class MyApp extends StatelessWidget {
         Provider<ReturnsUseCases>(
           create: (context) => ReturnsUseCases(
             Provider.of<ReturnsRepositoryImpl>(context, listen: false),
+            Provider.of<SalesUseCases>(context, listen: false),
+            Provider.of<InventoryUseCases>(context, listen: false),
           ),
         ),
       ],

--- a/lib/presentation/management/procurement_screen.dart
+++ b/lib/presentation/management/procurement_screen.dart
@@ -327,7 +327,10 @@ class ProcurementScreen extends StatelessWidget {
             ElevatedButton.icon(
               onPressed: () async {
                 await useCases.receiveByWarehouse(
-                    request, user.uid, user.name);
+                    request,
+                    user.uid,
+                    user.name,
+                    Provider.of<InventoryUseCases>(context, listen: false));
                 Navigator.pop(context);
               },
               icon: const Icon(Icons.inventory_2_outlined,

--- a/lib/presentation/sales/create_sales_order_screen.dart
+++ b/lib/presentation/sales/create_sales_order_screen.dart
@@ -212,7 +212,7 @@ class _CreateSalesOrderScreenState extends State<CreateSalesOrderScreen> {
     });
   }
 
-  Future<void> _submitOrder(SalesUseCases useCases, UserModel currentUser) async {
+  Future<void> _submitOrder(SalesUseCases useCases, InventoryUseCases inventoryUseCases, UserModel currentUser) async {
     if (_formKey.currentState!.validate() && _orderItems.isNotEmpty) {
       if (_selectedCustomer == null) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -260,6 +260,7 @@ class _CreateSalesOrderScreenState extends State<CreateSalesOrderScreen> {
           totalAmount: _totalAmount,
           customerSignatureFile: signatureFile,
           customerSignatureBytes: signatureBytes,
+          inventoryUseCases: inventoryUseCases,
         );
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(AppLocalizations.of(context)!.salesOrderCreatedSuccessfully)),
@@ -433,7 +434,10 @@ class _CreateSalesOrderScreenState extends State<CreateSalesOrderScreen> {
               ElevatedButton.icon(
                 icon: Icon(Icons.send, color: Colors.white),
                 label: Text(appLocalizations.submitOrder, style: TextStyle(color: Colors.white)),
-                onPressed: () => _submitOrder(salesUseCases, currentUser),
+                onPressed: () => _submitOrder(
+                    salesUseCases,
+                    Provider.of<InventoryUseCases>(context, listen: false),
+                    currentUser),
                 style: ElevatedButton.styleFrom(
                   backgroundColor: AppColors.primary,
                   minimumSize: Size(double.infinity, 55),


### PR DESCRIPTION
## Summary
- check inventory before creating sales orders
- ensure enough raw materials for new production orders
- update stock when warehouse receives purchases
- process returns by restocking items
- expose inventory balance lookup

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cf95dbce0832aaa36e5f741cb0be5