### PR TITLE
Add item type and amount handling in purchase requests

### DIFF
--- a/lib/data/models/purchase_request_model.dart
+++ b/lib/data/models/purchase_request_model.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'inventory_balance_model.dart';
 
 enum PurchaseRequestStatus {
   awaitingApproval, // بانتظار اعتماد المحاسب
@@ -21,10 +22,13 @@ class PurchaseRequestItem {
   final String itemId;
   final String itemName;
   final int quantity;
+  final InventoryItemType itemType;
+
   PurchaseRequestItem({
     required this.itemId,
     required this.itemName,
     required this.quantity,
+    required this.itemType,
   });
 
   factory PurchaseRequestItem.fromMap(Map<String, dynamic> map) {
@@ -32,6 +36,7 @@ class PurchaseRequestItem {
       itemId: map['itemId'] ?? '',
       itemName: map['itemName'] ?? '',
       quantity: map['quantity'] ?? 0,
+      itemType: inventoryItemTypeFromString(map['itemType'] ?? 'raw'),
     );
   }
 
@@ -40,7 +45,22 @@ class PurchaseRequestItem {
       'itemId': itemId,
       'itemName': itemName,
       'quantity': quantity,
+      'itemType': inventoryItemTypeToString(itemType),
     };
+  }
+
+  PurchaseRequestItem copyWith({
+    String? itemId,
+    String? itemName,
+    int? quantity,
+    InventoryItemType? itemType,
+  }) {
+    return PurchaseRequestItem(
+      itemId: itemId ?? this.itemId,
+      itemName: itemName ?? this.itemName,
+      quantity: quantity ?? this.quantity,
+      itemType: itemType ?? this.itemType,
+    );
   }
 }
 

--- a/lib/domain/usecases/procurement_usecases.dart
+++ b/lib/domain/usecases/procurement_usecases.dart
@@ -19,9 +19,13 @@ class ProcurementUseCases {
   }
 
   Future<void> approveByAccountant(
-      PurchaseRequestModel request, String approverUid, String approverName) async {
+      PurchaseRequestModel request,
+      String approverUid,
+      String approverName,
+      double amount) async {
     final updated = request.copyWith(
       status: PurchaseRequestStatus.awaitingWarehouse,
+      totalAmount: amount,
       accountantUid: approverUid,
       accountantName: approverName,
       accountantApprovedAt: Timestamp.now(),
@@ -55,7 +59,7 @@ class ProcurementUseCases {
       await inventoryUseCases.adjustInventoryWithNotification(
         itemId: item.itemId,
         itemName: item.itemName,
-        type: InventoryItemType.rawMaterial,
+        type: item.itemType,
         delta: item.quantity.toDouble(),
       );
     }

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -461,6 +461,7 @@
   "selectUnit": "اختر الوحدة",
   "finishedProducts": "الإنتاج التام",
   "spareParts": "قطع الغيار",
+  "other": "أخرى",
   "noData": "لا توجد بيانات",
   "creditLimit": "الحد الائتماني",
   "currentDebt": "المديونية الحالية",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -470,6 +470,7 @@
   "selectUnit": "اختر الوحدة",
   "finishedProducts": "Finished Products",
   "spareParts": "Spare Parts",
+  "other": "Other",
   "noData": "No data",
   "creditLimit": "Credit Limit",
   "currentDebt": "Current Debt",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -453,6 +453,7 @@ class AppLocalizations {
   String get selectUnit => _strings["selectUnit"] ?? "selectUnit";
   String get finishedProducts => _strings["finishedProducts"] ?? "finishedProducts";
   String get spareParts => _strings["spareParts"] ?? "spareParts";
+  String get other => _strings["other"] ?? "other";
   String get noData => _strings["noData"] ?? "noData";
   String get creditLimit => _strings["creditLimit"] ?? "creditLimit";
   String get currentDebt => _strings["currentDebt"] ?? "currentDebt";


### PR DESCRIPTION
## Summary
- capture item type for purchase request items
- let accountant specify purchase amount and update inventory based on item type
- extend localization with `other` translation
- update procurement UI for new fields

## Testing
- `dart format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e40fab6c4832aaad12ae448709513