### PR TITLE
Implement machine counter handover log

### DIFF
--- a/lib/data/models/production_daily_log_model.dart
+++ b/lib/data/models/production_daily_log_model.dart
@@ -7,6 +7,7 @@ class ProductionDailyLogModel {
   final String orderId;
   final String supervisorUid;
   final String supervisorName;
+  final int? counterReading;
   final String? notes;
   final List<String> imageUrls;
   final Timestamp createdAt;
@@ -16,6 +17,7 @@ class ProductionDailyLogModel {
     required this.orderId,
     required this.supervisorUid,
     required this.supervisorName,
+    this.counterReading,
     this.notes,
     this.imageUrls = const [],
     required this.createdAt,
@@ -28,6 +30,7 @@ class ProductionDailyLogModel {
       orderId: data['orderId'] ?? '',
       supervisorUid: data['supervisorUid'] ?? '',
       supervisorName: data['supervisorName'] ?? '',
+      counterReading: data['counterReading'],
       notes: data['notes'],
       imageUrls: List<String>.from(data['imageUrls'] ?? []),
       createdAt: data['createdAt'] ?? Timestamp.now(),
@@ -39,6 +42,7 @@ class ProductionDailyLogModel {
       'orderId': orderId,
       'supervisorUid': supervisorUid,
       'supervisorName': supervisorName,
+      'counterReading': counterReading,
       'notes': notes,
       'imageUrls': imageUrls,
       'createdAt': createdAt,
@@ -50,6 +54,7 @@ class ProductionDailyLogModel {
     String? orderId,
     String? supervisorUid,
     String? supervisorName,
+    int? counterReading,
     String? notes,
     List<String>? imageUrls,
     Timestamp? createdAt,
@@ -59,6 +64,7 @@ class ProductionDailyLogModel {
       orderId: orderId ?? this.orderId,
       supervisorUid: supervisorUid ?? this.supervisorUid,
       supervisorName: supervisorName ?? this.supervisorName,
+      counterReading: counterReading ?? this.counterReading,
       notes: notes ?? this.notes,
       imageUrls: imageUrls ?? this.imageUrls,
       createdAt: createdAt ?? this.createdAt,

--- a/lib/domain/usecases/production_daily_log_usecases.dart
+++ b/lib/domain/usecases/production_daily_log_usecases.dart
@@ -20,6 +20,7 @@ class ProductionDailyLogUseCases {
     required String orderId,
     required String supervisorUid,
     required String supervisorName,
+    int? counterReading,
     String? notes,
     List<File>? images,
   }) async {
@@ -39,6 +40,7 @@ class ProductionDailyLogUseCases {
       orderId: orderId,
       supervisorUid: supervisorUid,
       supervisorName: supervisorName,
+      counterReading: counterReading,
       notes: notes,
       imageUrls: imageUrls,
       createdAt: Timestamp.now(),

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -109,6 +109,7 @@
   "maintenanceType": "نوع الصيانة",
   "responsiblePerson": "المسؤول",
   "notes": "الملاحظات",
+  "counterReading": "قراءة العداد",
   "checklist": "قائمة تحقق",
   "salesModule": "وحدة المبيعات",
   "inventoryModule": "وحدة المخزون",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -146,6 +146,7 @@
   "maintenanceType": "نوع الصيانة",
   "responsiblePerson": "المسؤول",
   "notes": "الملاحظات",
+  "counterReading": "Counter Reading",
   "checklist": "قائمة تحقق",
   "salesModule": "وحدة المبيعات",
   "inventoryModule": "Inventory Module",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -108,6 +108,7 @@ class AppLocalizations {
   String get maintenanceType => _strings["maintenanceType"] ?? "maintenanceType";
   String get responsiblePerson => _strings["responsiblePerson"] ?? "responsiblePerson";
   String get notes => _strings["notes"] ?? "notes";
+  String get counterReading => _strings["counterReading"] ?? "counterReading";
   String get checklist => _strings["checklist"] ?? "checklist";
   String get salesModule => _strings["salesModule"] ?? "salesModule";
   String get inventoryModule => _strings["inventoryModule"] ?? "inventoryModule";

--- a/lib/presentation/production/production_order_detail_screen.dart
+++ b/lib/presentation/production/production_order_detail_screen.dart
@@ -388,6 +388,12 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
                               style: const TextStyle(fontWeight: FontWeight.bold),
                               textAlign: TextAlign.right,
                             ),
+                            if (log.counterReading != null)
+                              Padding(
+                                padding: const EdgeInsets.symmetric(vertical: 4.0),
+                                child: Text('قراءة العداد: ${log.counterReading}',
+                                    textAlign: TextAlign.right),
+                              ),
                             if (log.notes != null && log.notes!.isNotEmpty)
                               Padding(
                                 padding: const EdgeInsets.symmetric(vertical: 4.0),
@@ -1094,6 +1100,7 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
       UserModel currentUser) async {
     List<File> logImages = [];
     String? notes;
+    int? counterReading;
 
     await showDialog(
       context: context,
@@ -1113,6 +1120,17 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
                         border: OutlineInputBorder(),
                       ),
                       maxLines: 3,
+                      textAlign: TextAlign.right,
+                      textDirection: TextDirection.rtl,
+                    ),
+                    const SizedBox(height: 16),
+                    TextField(
+                      keyboardType: TextInputType.number,
+                      onChanged: (v) => counterReading = int.tryParse(v),
+                      decoration: const InputDecoration(
+                        labelText: 'قراءة العداد',
+                        border: OutlineInputBorder(),
+                      ),
                       textAlign: TextAlign.right,
                       textDirection: TextDirection.rtl,
                     ),
@@ -1170,6 +1188,7 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
                       orderId: order.id,
                       supervisorUid: currentUser.uid,
                       supervisorName: currentUser.name,
+                      counterReading: counterReading,
                       notes: notes,
                       images: logImages,
                     );


### PR DESCRIPTION
## Summary
- add counterReading field to production daily logs
- store new field from UI and in the use cases
- display machine counter reading in logs list
- localize new string "counterReading"

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e44979b64832a999bf10614158361