### PR TITLE
Add shift handover tracking

### DIFF
--- a/lib/data/datasources/shift_handover_datasource.dart
+++ b/lib/data/datasources/shift_handover_datasource.dart
@@ -1,0 +1,21 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/shift_handover_model.dart';
+
+class ShiftHandoverDatasource {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+
+  Stream<List<ShiftHandoverModel>> getHandoversForOrder(String orderId) {
+    return _firestore
+        .collection('shift_handovers')
+        .where('orderId', isEqualTo: orderId)
+        .orderBy('createdAt', descending: true)
+        .snapshots()
+        .map((snapshot) => snapshot.docs
+            .map((doc) => ShiftHandoverModel.fromDocumentSnapshot(doc))
+            .toList());
+  }
+
+  Future<void> addHandover(ShiftHandoverModel handover) async {
+    await _firestore.collection('shift_handovers').add(handover.toMap());
+  }
+}

--- a/lib/data/models/shift_handover_model.dart
+++ b/lib/data/models/shift_handover_model.dart
@@ -1,0 +1,77 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class ShiftHandoverModel {
+  final String id;
+  final String orderId;
+  final String fromSupervisorUid;
+  final String fromSupervisorName;
+  final String toSupervisorUid;
+  final String toSupervisorName;
+  final double meterReading;
+  final String? notes;
+  final Timestamp createdAt;
+
+  ShiftHandoverModel({
+    required this.id,
+    required this.orderId,
+    required this.fromSupervisorUid,
+    required this.fromSupervisorName,
+    required this.toSupervisorUid,
+    required this.toSupervisorName,
+    required this.meterReading,
+    this.notes,
+    required this.createdAt,
+  });
+
+  factory ShiftHandoverModel.fromDocumentSnapshot(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return ShiftHandoverModel(
+      id: doc.id,
+      orderId: data['orderId'] ?? '',
+      fromSupervisorUid: data['fromSupervisorUid'] ?? '',
+      fromSupervisorName: data['fromSupervisorName'] ?? '',
+      toSupervisorUid: data['toSupervisorUid'] ?? '',
+      toSupervisorName: data['toSupervisorName'] ?? '',
+      meterReading: (data['meterReading'] as num?)?.toDouble() ?? 0.0,
+      notes: data['notes'],
+      createdAt: data['createdAt'] ?? Timestamp.now(),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'orderId': orderId,
+      'fromSupervisorUid': fromSupervisorUid,
+      'fromSupervisorName': fromSupervisorName,
+      'toSupervisorUid': toSupervisorUid,
+      'toSupervisorName': toSupervisorName,
+      'meterReading': meterReading,
+      'notes': notes,
+      'createdAt': createdAt,
+    };
+  }
+
+  ShiftHandoverModel copyWith({
+    String? id,
+    String? orderId,
+    String? fromSupervisorUid,
+    String? fromSupervisorName,
+    String? toSupervisorUid,
+    String? toSupervisorName,
+    double? meterReading,
+    String? notes,
+    Timestamp? createdAt,
+  }) {
+    return ShiftHandoverModel(
+      id: id ?? this.id,
+      orderId: orderId ?? this.orderId,
+      fromSupervisorUid: fromSupervisorUid ?? this.fromSupervisorUid,
+      fromSupervisorName: fromSupervisorName ?? this.fromSupervisorName,
+      toSupervisorUid: toSupervisorUid ?? this.toSupervisorUid,
+      toSupervisorName: toSupervisorName ?? this.toSupervisorName,
+      meterReading: meterReading ?? this.meterReading,
+      notes: notes ?? this.notes,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+}

--- a/lib/data/repositories/shift_handover_repository_impl.dart
+++ b/lib/data/repositories/shift_handover_repository_impl.dart
@@ -1,0 +1,18 @@
+import 'package:plastic_factory_management/domain/repositories/shift_handover_repository.dart';
+import '../datasources/shift_handover_datasource.dart';
+import '../models/shift_handover_model.dart';
+
+class ShiftHandoverRepositoryImpl implements ShiftHandoverRepository {
+  final ShiftHandoverDatasource datasource;
+  ShiftHandoverRepositoryImpl(this.datasource);
+
+  @override
+  Stream<List<ShiftHandoverModel>> getHandoversForOrder(String orderId) {
+    return datasource.getHandoversForOrder(orderId);
+  }
+
+  @override
+  Future<void> addHandover(ShiftHandoverModel handover) {
+    return datasource.addHandover(handover);
+  }
+}

--- a/lib/domain/repositories/shift_handover_repository.dart
+++ b/lib/domain/repositories/shift_handover_repository.dart
@@ -1,0 +1,6 @@
+import 'package:plastic_factory_management/data/models/shift_handover_model.dart';
+
+abstract class ShiftHandoverRepository {
+  Stream<List<ShiftHandoverModel>> getHandoversForOrder(String orderId);
+  Future<void> addHandover(ShiftHandoverModel handover);
+}

--- a/lib/domain/usecases/shift_handover_usecases.dart
+++ b/lib/domain/usecases/shift_handover_usecases.dart
@@ -1,0 +1,35 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:plastic_factory_management/data/models/shift_handover_model.dart';
+import 'package:plastic_factory_management/data/models/user_model.dart';
+import 'package:plastic_factory_management/domain/repositories/shift_handover_repository.dart';
+
+class ShiftHandoverUseCases {
+  final ShiftHandoverRepository repository;
+
+  ShiftHandoverUseCases(this.repository);
+
+  Stream<List<ShiftHandoverModel>> getHandoversForOrder(String orderId) {
+    return repository.getHandoversForOrder(orderId);
+  }
+
+  Future<void> addHandover({
+    required String orderId,
+    required UserModel fromSupervisor,
+    required UserModel toSupervisor,
+    required double meterReading,
+    String? notes,
+  }) async {
+    final handover = ShiftHandoverModel(
+      id: '',
+      orderId: orderId,
+      fromSupervisorUid: fromSupervisor.uid,
+      fromSupervisorName: fromSupervisor.name,
+      toSupervisorUid: toSupervisor.uid,
+      toSupervisorName: toSupervisor.name,
+      meterReading: meterReading,
+      notes: notes,
+      createdAt: Timestamp.now(),
+    );
+    await repository.addHandover(handover);
+  }
+}

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -495,6 +495,8 @@
   "rejectedQuantity": "الكمية المرفوضة",
   "acceptedQuantity": "الكمية المقبولة",
   "shiftSupervisor": "مشرف الوردية",
+  "shiftHandover": "تسليم الوردية",
+  "shiftHandoverHistory": "سجل تسليم الورديات",
   "defectAnalysis": "تحليل التالف",
   "qualityChecks": "سجلات الجودة",
   "defectPhotos": "صور التالف",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -504,6 +504,8 @@
   "rejectedQuantity": "Rejected Quantity",
   "acceptedQuantity": "Accepted Quantity",
   "shiftSupervisor": "Shift Supervisor",
+  "shiftHandover": "Shift Handover",
+  "shiftHandoverHistory": "Shift Handover History",
   "defectAnalysis": "Defect Analysis",
   "qualityChecks": "Quality Checks",
   "defectPhotos": "Defect Photos",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,6 +24,9 @@ import 'package:plastic_factory_management/domain/usecases/production_order_usec
 import 'package:plastic_factory_management/data/datasources/production_daily_log_datasource.dart';
 import 'package:plastic_factory_management/data/repositories/production_daily_log_repository_impl.dart';
 import 'package:plastic_factory_management/domain/usecases/production_daily_log_usecases.dart';
+import 'package:plastic_factory_management/data/datasources/shift_handover_datasource.dart';
+import 'package:plastic_factory_management/data/repositories/shift_handover_repository_impl.dart';
+import 'package:plastic_factory_management/domain/usecases/shift_handover_usecases.dart';
 
 // استيرادات Inventory
 import 'package:plastic_factory_management/data/datasources/inventory_datasource.dart';
@@ -214,6 +217,20 @@ class MyApp extends StatelessWidget {
         Provider<ProductionDailyLogUseCases>(
           create: (context) => ProductionDailyLogUseCases(
             Provider.of<ProductionDailyLogRepositoryImpl>(context, listen: false),
+          ),
+        ),
+        // Shift Handover dependencies
+        Provider<ShiftHandoverDatasource>(
+          create: (_) => ShiftHandoverDatasource(),
+        ),
+        Provider<ShiftHandoverRepositoryImpl>(
+          create: (context) => ShiftHandoverRepositoryImpl(
+            Provider.of<ShiftHandoverDatasource>(context, listen: false),
+          ),
+        ),
+        Provider<ShiftHandoverUseCases>(
+          create: (context) => ShiftHandoverUseCases(
+            Provider.of<ShiftHandoverRepositoryImpl>(context, listen: false),
           ),
         ),
         // توفير Machinery & Operator Dependencies


### PR DESCRIPTION
## Summary
- add shift handover data model, datasource, repository, and usecases
- register shift handover providers
- extend production order detail screen with handover log and dialog
- localize new strings

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e47654384832a92e864b5473d4ded