### PR TITLE
Prevent selecting machines under maintenance

### DIFF
--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -329,6 +329,7 @@
   "enterActualTime": "الرجاء إدخال الوقت الفعلي المستغرق.",
   "productionStartingMachineSelection": "اختر الآلة التي سيتم تشغيلها لهذا الطلب:",
   "machineRequired": "الآلة مطلوبة.",
+  "machineUnderMaintenanceMessage": "لا يمكن اختيار هذه الآلة لأنها تحت الصيانة",
   "finishMachineWork": "إنهاء عمل المكينة",
   "installMoldCompletion": "إتمام تركيب القالب",
   "deliverMoldToSupervisor": "تسليم القالب لمشرف الإنتاج",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -369,6 +369,7 @@
   "enterActualTime": "الرجاء إدخال الوقت الفعلي المستغرق.",
   "productionStartingMachineSelection": "اختر الآلة التي سيتم تشغيلها لهذا الطلب:",
   "machineRequired": "الآلة مطلوبة.",
+  "machineUnderMaintenanceMessage": "This machine is under maintenance and cannot be selected.",
   "finishMachineWork": "إنهاء عمل المكينة",
   "installMoldCompletion": "إتمام تركيب القالب",
   "deliverMoldToSupervisor": "تسليم القالب لمشرف الإنتاج",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -95,6 +95,7 @@ class AppLocalizations {
   String get ready => _strings["ready"] ?? "ready";
   String get inOperation => _strings["inOperation"] ?? "inOperation";
   String get underMaintenance => _strings["underMaintenance"] ?? "underMaintenance";
+  String get machineUnderMaintenanceMessage => _strings["machineUnderMaintenanceMessage"] ?? "machineUnderMaintenanceMessage";
   String get maintenanceLog => _strings["maintenanceLog"] ?? "maintenanceLog";
   String get operatorProfiles => _strings["operatorProfiles"] ?? "operatorProfiles";
   String get employeeName => _strings["employeeName"] ?? "employeeName";

--- a/lib/presentation/production/create_production_order_screen.dart
+++ b/lib/presentation/production/create_production_order_screen.dart
@@ -132,7 +132,7 @@ class _CreateProductionOrderScreenState extends State<CreateProductionOrderScree
               ),
               SizedBox(height: 16),
               // Required Quantity
-              StreamBuilder<List<MachineModel>>( 
+              StreamBuilder<List<MachineModel>>(
                 stream: machineryUseCases.getMachines(),
                 builder: (context, snapshot) {
                   if (snapshot.connectionState == ConnectionState.waiting) {
@@ -152,12 +152,21 @@ class _CreateProductionOrderScreenState extends State<CreateProductionOrderScree
                       border: const OutlineInputBorder(),
                     ),
                     items: snapshot.data!.map((machine) {
+                      final label = machine.status == MachineStatus.underMaintenance
+                          ? '${machine.name} (${appLocalizations.underMaintenance})'
+                          : machine.name;
                       return DropdownMenuItem(
                         value: machine,
-                        child: Text(machine.name, textDirection: TextDirection.rtl),
+                        child: Text(label, textDirection: TextDirection.rtl),
                       );
                     }).toList(),
                     onChanged: (MachineModel? newValue) {
+                      if (newValue != null && newValue.status == MachineStatus.underMaintenance) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(content: Text(appLocalizations.machineUnderMaintenanceMessage)),
+                        );
+                        return;
+                      }
                       setState(() {
                         _selectedMachine = newValue;
                       });

--- a/lib/presentation/sales/sales_orders_list_screen.dart
+++ b/lib/presentation/sales/sales_orders_list_screen.dart
@@ -1553,7 +1553,7 @@ class _SalesOrdersListScreenState extends State<SalesOrdersListScreen> {
             Text(appLocalizations.confirmForwardToMoldSupervisor,
                 textAlign: TextAlign.center),
             const SizedBox(height: 12),
-            StreamBuilder<List<MachineModel>>( 
+            StreamBuilder<List<MachineModel>>(
               stream: machineryUseCases.getMachines(),
               builder: (context, snapshot) {
                 if (!snapshot.hasData) {
@@ -1575,13 +1575,25 @@ class _SalesOrdersListScreenState extends State<SalesOrdersListScreen> {
                     border: const OutlineInputBorder(),
                   ),
                   items: machines
-                      .map((machine) => DropdownMenuItem(
-                            value: machine,
-                            child: Text(machine.name,
-                                textDirection: TextDirection.rtl),
-                          ))
+                      .map((machine) {
+                        final label = machine.status == MachineStatus.underMaintenance
+                            ? '${machine.name} (${appLocalizations.underMaintenance})'
+                            : machine.name;
+                        return DropdownMenuItem(
+                          value: machine,
+                          child: Text(label, textDirection: TextDirection.rtl),
+                        );
+                      })
                       .toList(),
-                  onChanged: (val) => selectedMachine = val,
+                  onChanged: (val) {
+                    if (val != null && val.status == MachineStatus.underMaintenance) {
+                      ScaffoldMessenger.of(parentContext).showSnackBar(
+                        SnackBar(content: Text(appLocalizations.machineUnderMaintenanceMessage)),
+                      );
+                      return;
+                    }
+                    selectedMachine = val;
+                  },
                   validator: (value) =>
                       value == null ? appLocalizations.machineRequired : null,
                 );


### PR DESCRIPTION
## Summary
- add `machineUnderMaintenanceMessage` translation
- expose new translation in `AppLocalizations`
- show status in machine dropdowns and block selection if under maintenance

## Testing
- `flutter` and `dart` were unavailable, so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_686e49ca8a28832ab29f3dd59468e7c7