### PR TITLE
Update procurement approval flow

### DIFF
--- a/lib/domain/usecases/procurement_usecases.dart
+++ b/lib/domain/usecases/procurement_usecases.dart
@@ -31,6 +31,16 @@ class ProcurementUseCases {
       accountantApprovedAt: Timestamp.now(),
     );
     await repository.updatePurchaseRequest(updated);
+
+    // adjust inventory quantities once approved
+    for (final item in request.items) {
+      await inventoryUseCases.adjustInventoryWithNotification(
+        itemId: item.itemId,
+        itemName: item.itemName,
+        type: item.itemType,
+        delta: item.quantity.toDouble(),
+      );
+    }
   }
 
   Future<void> rejectByAccountant(
@@ -54,14 +64,5 @@ class ProcurementUseCases {
       warehouseReceivedAt: Timestamp.now(),
     );
     await repository.updatePurchaseRequest(updated);
-
-    for (final item in request.items) {
-      await inventoryUseCases.adjustInventoryWithNotification(
-        itemId: item.itemId,
-        itemName: item.itemName,
-        type: item.itemType,
-        delta: item.quantity.toDouble(),
-      );
-    }
   }
 }

--- a/lib/presentation/management/procurement_screen.dart
+++ b/lib/presentation/management/procurement_screen.dart
@@ -111,7 +111,22 @@ class ProcurementScreen extends StatelessWidget {
                         _buildInfoRow(appLocalizations.orderDate,
                             intl.DateFormat('yyyy-MM-dd').format(r.createdAt.toDate()),
                             icon: Icons.calendar_today_outlined),
-                        _buildInfoRow(appLocalizations.quantity, r.items.length.toString(), icon: Icons.list_alt),
+                        _buildInfoRow(appLocalizations.quantity,
+                            r.items.length.toString(), icon: Icons.list_alt),
+                        if (r.totalAmount > 0)
+                          _buildInfoRow(appLocalizations.amount,
+                              r.totalAmount.toString(),
+                              icon: Icons.price_change_outlined),
+                        if (r.accountantApprovedAt != null)
+                          _buildInfoRow(
+                              appLocalizations.approvalDate,
+                              intl.DateFormat('yyyy-MM-dd')
+                                  .format(r.accountantApprovedAt!.toDate()),
+                              icon: Icons.calendar_month_outlined),
+                        if (r.accountantName != null)
+                          _buildInfoRow(appLocalizations.approvedBy,
+                              r.accountantName ?? appLocalizations.unknown,
+                              icon: Icons.person_outline),
                       ],
                     ),
                   ),
@@ -285,9 +300,22 @@ class ProcurementScreen extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            ...request.items.map((e) => Text('${e.itemName} x${e.quantity}', textDirection: TextDirection.rtl)),
+            ...request.items.map((e) => Text('${e.itemName} x${e.quantity}',
+                textDirection: TextDirection.rtl)),
             const SizedBox(height: 8),
-            Text('${appLocalizations.statusColon}${_statusToArabic(request.status, context)}', textDirection: TextDirection.rtl),
+            _buildInfoRow(appLocalizations.status,
+                _statusToArabic(request.status, context)),
+            if (request.accountantApprovedAt != null)
+              _buildInfoRow(
+                  appLocalizations.approvalDate,
+                  intl.DateFormat('yyyy-MM-dd')
+                      .format(request.accountantApprovedAt!.toDate())),
+            if (request.totalAmount > 0)
+              _buildInfoRow(
+                  appLocalizations.amount, request.totalAmount.toString()),
+            if (request.accountantName != null)
+              _buildInfoRow(appLocalizations.approvedBy,
+                  request.accountantName ?? appLocalizations.unknown),
             if (user != null &&
                 user.userRoleEnum == UserRole.accountant &&
                 request.status == PurchaseRequestStatus.awaitingApproval) ...[


### PR DESCRIPTION
## Summary
- update procurement approval use case to adjust inventory when approved
- show purchase request details like amount, approval date and approver

## Testing
- `pytest -q` *(no tests found)*
- `flutter analyze` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e534ec578832a83eafe6f16d06f25