### PR TITLE
Add awaitingOperationsForward status

### DIFF
--- a/lib/data/models/sales_order_model.dart
+++ b/lib/data/models/sales_order_model.dart
@@ -8,6 +8,7 @@ enum SalesOrderStatus {
   pendingApproval,    // بانتظار اعتماد المحاسب
   pendingFulfillment, // بانتظار قرار منسق طلبات الإنتاج
   warehouseProcessing, // لدى أمين المخزن للتجهيز
+  awaitingOperationsForward, // بانتظار تحويل مسؤول العمليات
   awaitingMoldApproval, // بانتظار اعتماد مشرف القوالب
   inProduction,       // قيد الإنتاج بعد تحديد موعد التسليم
   fulfilled,          // تم التوريد
@@ -24,6 +25,8 @@ extension SalesOrderStatusExtension on SalesOrderStatus {
         return 'بانتظار منسق الطلبات';
       case SalesOrderStatus.warehouseProcessing:
         return 'قيد التحضير بالمخزن';
+      case SalesOrderStatus.awaitingOperationsForward:
+        return 'بانتظار تحويل إلى مشرف القوالب';
       case SalesOrderStatus.awaitingMoldApproval:
         return 'بانتظار اعتماد القوالب';
       case SalesOrderStatus.inProduction:

--- a/lib/domain/usecases/sales_usecases.dart
+++ b/lib/domain/usecases/sales_usecases.dart
@@ -276,7 +276,7 @@ class SalesUseCases {
       deliveryTime: deliveryTime != null
           ? Timestamp.fromDate(deliveryTime)
           : order.deliveryTime,
-      status: SalesOrderStatus.warehouseProcessing,
+      status: SalesOrderStatus.awaitingOperationsForward,
     );
     await repository.updateSalesOrder(updated);
   }

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -278,6 +278,7 @@
   "pendingApproval": "بانتظار الاعتماد",
   "pendingFulfillment": "بانتظار منسق الطلبات",
   "warehouseProcessing": "قيد التحضير بالمخزن",
+  "awaitingOperationsForward": "بانتظار مسؤول العمليات للتحويل إلى مشرف القوالب",
   "fulfilled": "تم التوريد",
   "rejected": "مرفوض",
   "markAsFulfilled": "تحديد كمورد",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -318,6 +318,7 @@
   "pendingApproval": "بانتظار الاعتماد",
   "pendingFulfillment": "بانتظار منسق الطلبات",
   "warehouseProcessing": "قيد التحضير بالمخزن",
+  "awaitingOperationsForward": "Awaiting operations manager to forward",
   "fulfilled": "تم التوريد",
   "rejected": "مرفوض",
   "markAsFulfilled": "تحديد كمورد",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -279,6 +279,7 @@ class AppLocalizations {
   String get pendingApproval => _strings["pendingApproval"] ?? "pendingApproval";
   String get pendingFulfillment => _strings["pendingFulfillment"] ?? "pendingFulfillment";
   String get warehouseProcessing => _strings["warehouseProcessing"] ?? "warehouseProcessing";
+  String get awaitingOperationsForward => _strings["awaitingOperationsForward"] ?? "awaitingOperationsForward";
   String get fulfilled => _strings["fulfilled"] ?? "fulfilled";
   String get rejected => _strings["rejected"] ?? "rejected";
   String get markAsFulfilled => _strings["markAsFulfilled"] ?? "markAsFulfilled";

--- a/lib/presentation/sales/sales_order_detail_page.dart
+++ b/lib/presentation/sales/sales_order_detail_page.dart
@@ -157,6 +157,8 @@ class _SalesOrderDetailPageState extends State<SalesOrderDetailPage> {
         return AppColors.secondary;
       case SalesOrderStatus.warehouseProcessing:
         return Colors.blue.shade700;
+      case SalesOrderStatus.awaitingOperationsForward:
+        return Colors.orange.shade700;
       case SalesOrderStatus.inProduction:
         return Colors.deepPurple.shade700;
       case SalesOrderStatus.fulfilled:

--- a/lib/presentation/sales/sales_orders_list_screen.dart
+++ b/lib/presentation/sales/sales_orders_list_screen.dart
@@ -486,7 +486,7 @@ class _SalesOrdersListScreenState extends State<SalesOrdersListScreen> {
       );
 
     } else if (isOperationsOfficer &&
-        order.status == SalesOrderStatus.warehouseProcessing) {
+        order.status == SalesOrderStatus.awaitingOperationsForward) {
       actions.add(
         ElevatedButton.icon(
           icon: const Icon(Icons.send, color: Colors.white),
@@ -541,6 +541,8 @@ class _SalesOrdersListScreenState extends State<SalesOrdersListScreen> {
         return AppColors.secondary; // Use a distinct color for this stage
       case SalesOrderStatus.warehouseProcessing:
         return Colors.blue.shade700;
+      case SalesOrderStatus.awaitingOperationsForward:
+        return Colors.orange.shade700;
       case SalesOrderStatus.inProduction:
         return Colors.deepPurple.shade700;
       case SalesOrderStatus.fulfilled:


### PR DESCRIPTION
## Summary
- add new `awaitingOperationsForward` status for sales orders
- update warehouse documentation to move order to the new status
- show forward-to-mold button only after storekeeper approval
- localize the new status and update UI colors

## Testing
- `flutter test` *(fails: flutter not installed)*
- `dart analyze` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e55395d64832a8a571db20c369e50