### PR TITLE
Update sales order status after mold approval

### DIFF
--- a/lib/domain/usecases/sales_usecases.dart
+++ b/lib/domain/usecases/sales_usecases.dart
@@ -394,6 +394,7 @@ class SalesUseCases {
     if (order.moldTasksEnabled) return;
     final updated = order.copyWith(
       moldTasksEnabled: true,
+      status: SalesOrderStatus.inProduction,
       moldSupervisorUid: supervisor.uid,
       moldSupervisorName: supervisor.name,
       moldSupervisorApprovedAt: Timestamp.now(),


### PR DESCRIPTION
## Summary
- mark sales orders as `inProduction` once mold supervisor approves

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e620ea918832a9a7e60a81d376a7a