### PR TITLE
Update production order status on handoff

### DIFF
--- a/lib/domain/usecases/production_order_usecases.dart
+++ b/lib/domain/usecases/production_order_usecases.dart
@@ -473,6 +473,7 @@ class ProductionOrderUseCases {
     } else if (stageName == 'تسليم القالب لمشرف الإنتاج') {
       nextStageName = 'بدء الإنتاج';
       updatedWorkflow.add(ProductionWorkflowStage(stageName: nextStageName, status: 'pending'));
+      newOverallStatus = ProductionOrderStatus.inProduction; // الطلب بات قيد الإنتاج بعد التسليم لمشرف الوردية
     } else if (stageName == 'بدء الإنتاج' && order.requiredQuantity > 0) { // Assuming this means a batch completed
       // This is where more complex batch logic would go. For simplicity,
       // let's assume 'بدء الإنتاج' completion means moving to 'انتهاء الإنتاج'.


### PR DESCRIPTION
## Summary
- when the mold supervisor hands the order to the shift supervisor mark it as `inProduction`

## Testing
- `dart format lib/domain/usecases/production_order_usecases.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e63b5c36c832aafdffb1278bc3f79