### PR TITLE
Restrict shift handover button to assigned supervisor

### DIFF
--- a/lib/presentation/production/production_order_detail_screen.dart
+++ b/lib/presentation/production/production_order_detail_screen.dart
@@ -25,6 +25,8 @@ import 'package:plastic_factory_management/theme/app_colors.dart';
 import 'package:plastic_factory_management/domain/usecases/shift_handover_usecases.dart';
 import 'package:plastic_factory_management/data/models/shift_handover_model.dart';
 import 'package:plastic_factory_management/domain/usecases/user_usecases.dart';
+import 'package:plastic_factory_management/data/models/sales_order_model.dart';
+import 'package:plastic_factory_management/domain/usecases/sales_usecases.dart';
 
 // شاشة تفاصيل طلب الإنتاج
 class ProductionOrderDetailScreen extends StatefulWidget {
@@ -48,6 +50,7 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
   String? _rejectionReason; // For delay justification
   TemplateModel? _template;
   MachineModel? _machine;
+  SalesOrderModel? _salesOrder;
 
   @override
   void initState() {
@@ -67,6 +70,15 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
     if (widget.order.machineId != null) {
       machineryUseCases.getMachineById(widget.order.machineId!).then((value) {
         if (mounted) setState(() => _machine = value);
+      });
+    }
+    if (widget.order.salesOrderId != null) {
+      final salesUseCases =
+          Provider.of<SalesUseCases>(context, listen: false);
+      salesUseCases
+          .getSalesOrderById(widget.order.salesOrderId!)
+          .then((value) {
+        if (mounted) setState(() => _salesOrder = value);
       });
     }
   }
@@ -473,7 +485,9 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
             ),
             const SizedBox(height: 8),
             if ((currentUser.userRoleEnum == UserRole.productionShiftSupervisor &&
-                    widget.order.status == ProductionOrderStatus.inProduction) ||
+                    widget.order.status == ProductionOrderStatus.inProduction &&
+                    _salesOrder != null &&
+                    _salesOrder!.shiftSupervisorUid == currentUser.uid) ||
                 (currentUser.userRoleEnum ==
                         UserRole.moldInstallationSupervisor &&
                     widget.order.currentStage ==

--- a/lib/presentation/sales/sales_order_detail_page.dart
+++ b/lib/presentation/sales/sales_order_detail_page.dart
@@ -195,7 +195,8 @@ class _SalesOrderDetailPageState extends State<SalesOrderDetailPage> {
               ],
               if (currentUser != null &&
                   currentUser.userRoleEnum == UserRole.productionShiftSupervisor &&
-                  widget.order.status == SalesOrderStatus.inProduction)
+                  widget.order.status == SalesOrderStatus.inProduction &&
+                  widget.order.shiftSupervisorUid == currentUser.uid)
                 Align(
                   alignment: Alignment.center,
                   child: ElevatedButton(


### PR DESCRIPTION
## Summary
- only allow the supervisor currently assigned to the order to hand over the shift
- load the related sales order in production details to check the assigned supervisor

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e89ba726c832a998cab4460991121