### PR TITLE
Add shift supervisor field to production orders

### DIFF
--- a/lib/data/models/production_order_model.dart
+++ b/lib/data/models/production_order_model.dart
@@ -160,6 +160,8 @@ class ProductionOrderModel {
   final String? machineId; // الآلة المستخدمة
   final String? machineName;
   final String? salesOrderId; // If this order was generated from a sales order
+  final String? shiftSupervisorUid; // UID مشرف الوردية المسؤول عن الإنتاج
+  final String? shiftSupervisorName; // اسم مشرف الوردية
   final String orderPreparerUid; // UID of the user who prepared the order
   final String orderPreparerName;
   final String orderPreparerRole; // Role of the user who prepared the order
@@ -182,6 +184,8 @@ class ProductionOrderModel {
     this.machineId,
     this.machineName,
     this.salesOrderId,
+    this.shiftSupervisorUid,
+    this.shiftSupervisorName,
     required this.orderPreparerUid,
     required this.orderPreparerName,
     required this.orderPreparerRole,
@@ -207,6 +211,8 @@ class ProductionOrderModel {
       machineId: data['machineId'],
       machineName: data['machineName'],
       salesOrderId: data['salesOrderId'],
+      shiftSupervisorUid: data['shiftSupervisorUid'],
+      shiftSupervisorName: data['shiftSupervisorName'],
       orderPreparerUid: data['orderPreparerUid'] ?? '',
       orderPreparerName: data['orderPreparerName'] ?? '',
       orderPreparerRole: data['orderPreparerRole'] ?? 'unknown',
@@ -234,6 +240,8 @@ class ProductionOrderModel {
       'machineId': machineId,
       'machineName': machineName,
       'salesOrderId': salesOrderId,
+      'shiftSupervisorUid': shiftSupervisorUid,
+      'shiftSupervisorName': shiftSupervisorName,
       'orderPreparerUid': orderPreparerUid,
       'orderPreparerName': orderPreparerName,
       'orderPreparerRole': orderPreparerRole,
@@ -259,6 +267,8 @@ class ProductionOrderModel {
     String? machineId,
     String? machineName,
     String? salesOrderId,
+    String? shiftSupervisorUid,
+    String? shiftSupervisorName,
     String? orderPreparerUid,
     String? orderPreparerName,
     String? orderPreparerRole,
@@ -281,6 +291,8 @@ class ProductionOrderModel {
       machineId: machineId ?? this.machineId,
       machineName: machineName ?? this.machineName,
       salesOrderId: salesOrderId ?? this.salesOrderId,
+      shiftSupervisorUid: shiftSupervisorUid ?? this.shiftSupervisorUid,
+      shiftSupervisorName: shiftSupervisorName ?? this.shiftSupervisorName,
       orderPreparerUid: orderPreparerUid ?? this.orderPreparerUid,
       orderPreparerName: orderPreparerName ?? this.orderPreparerName,
       orderPreparerRole: orderPreparerRole ?? this.orderPreparerRole,
@@ -292,5 +304,4 @@ class ProductionOrderModel {
       currentStage: currentStage ?? this.currentStage,
       workflowStages: workflowStages ?? this.workflowStages,
     );
-  }
-}
+  }}

--- a/lib/domain/usecases/production_order_usecases.dart
+++ b/lib/domain/usecases/production_order_usecases.dart
@@ -75,6 +75,7 @@ class ProductionOrderUseCases {
     required int requiredQuantity,
     MachineModel? selectedMachine,
     required UserModel orderPreparer, // Pass the current user model
+    required UserModel shiftSupervisor,
     String? salesOrderId,
   }) async {
     for (final material in selectedProduct.billOfMaterials) {
@@ -114,6 +115,8 @@ class ProductionOrderUseCases {
       templateName: null,
       machineId: selectedMachine?.id,
       machineName: selectedMachine?.name,
+      shiftSupervisorUid: shiftSupervisor.uid,
+      shiftSupervisorName: shiftSupervisor.name,
       orderPreparerUid: orderPreparer.uid,
       orderPreparerName: orderPreparer.name,
       orderPreparerRole: orderPreparer.userRoleEnum.toFirestoreString(),
@@ -171,6 +174,8 @@ class ProductionOrderUseCases {
         requiredQuantity: item.quantity,
       batchNumber: '${order.id}-$i',
       salesOrderId: order.id,
+      shiftSupervisorUid: order.shiftSupervisorUid,
+      shiftSupervisorName: order.shiftSupervisorName,
       orderPreparerUid: preparer.uid,
       orderPreparerName: preparer.name,
       orderPreparerRole: preparer.userRoleEnum.toFirestoreString(),

--- a/lib/presentation/production/production_order_detail_screen.dart
+++ b/lib/presentation/production/production_order_detail_screen.dart
@@ -241,6 +241,9 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
                 icon: Icons.confirmation_number),
             _buildDetailRow(appLocalizations.orderPreparer, widget.order.orderPreparerName,
                 icon: Icons.person),
+            _buildDetailRow(appLocalizations.shiftSupervisor,
+                widget.order.shiftSupervisorName ?? '-',
+                icon: Icons.supervisor_account_outlined),
             if (_template != null) ...[
               const SizedBox(height: 8),
               Text(appLocalizations.templateDetails,


### PR DESCRIPTION
## Summary
- track shift supervisor in `ProductionOrderModel`
- require shift supervisor when creating production orders
- show shift supervisor info in order details
- allow selecting shift supervisor in the create order form

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e8f8e4680832aa0eab92955921fc8