### PR TITLE
Enable production order shift handover updates

### DIFF
--- a/lib/domain/usecases/production_order_usecases.dart
+++ b/lib/domain/usecases/production_order_usecases.dart
@@ -568,4 +568,19 @@ class ProductionOrderUseCases {
   Future<ProductModel?> getProductById(String productId) {
     return repository.getProductById(productId);
   }
-}
+
+  /// Update the shift supervisor responsible for a production order
+  Future<void> updateShiftSupervisor(
+      ProductionOrderModel order, UserModel supervisor) async {
+    final updated = order.copyWith(
+      shiftSupervisorUid: supervisor.uid,
+      shiftSupervisorName: supervisor.name,
+    );
+    await repository.updateProductionOrder(updated);
+
+    await notificationUseCases.sendNotification(
+      userId: supervisor.uid,
+      title: 'تم اسناد طلب انتاج جديد',
+      message: 'يرجى متابعة أمر الإنتاج رقم ${order.batchNumber}',
+    );
+  }}

--- a/lib/presentation/production/production_order_detail_screen.dart
+++ b/lib/presentation/production/production_order_detail_screen.dart
@@ -1286,6 +1286,7 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
       BuildContext context, ProductionOrderModel order, UserModel currentUser) async {
     final userUseCases = Provider.of<UserUseCases>(context, listen: false);
     final handoverUseCases = Provider.of<ShiftHandoverUseCases>(context, listen: false);
+    final productionUseCases = Provider.of<ProductionOrderUseCases>(context, listen: false);
     final supervisors = await userUseCases.getUsersByRole(UserRole.productionShiftSupervisor);
     UserModel? selected;
     String? notes;
@@ -1355,6 +1356,7 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
                             meterReading: meter!,
                             notes: notes,
                           );
+                          await productionUseCases.updateShiftSupervisor(order, selected!);
                           ScaffoldMessenger.of(context).showSnackBar(
                             const SnackBar(content: Text('تم حفظ التسليم')),);
                         },


### PR DESCRIPTION
## Summary
- allow updating shift supervisor for production orders
- propagate supervisor change on shift handover dialog

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e9792a8b8832a92de00af0411a0c2