### PR TITLE
Fix missing localization getters and add context

### DIFF
--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -521,6 +521,9 @@ class AppLocalizations {
   String get shiftHandover => _strings["shiftHandover"] ?? "shiftHandover";
   String get shiftHandoverHistory =>
       _strings["shiftHandoverHistory"] ?? "shiftHandoverHistory";
+  String get shiftSupervisorFollowUp =>
+      _strings["shiftSupervisorFollowUp"] ?? "shiftSupervisorFollowUp";
+  String get addFollowUp => _strings["addFollowUp"] ?? "addFollowUp";
   String get defectAnalysis => _strings["defectAnalysis"] ?? "defectAnalysis";
   String get qualityChecks => _strings["qualityChecks"] ?? "qualityChecks";
   String get defectPhotos => _strings["defectPhotos"] ?? "defectPhotos";

--- a/lib/presentation/production/production_order_detail_screen.dart
+++ b/lib/presentation/production/production_order_detail_screen.dart
@@ -1176,6 +1176,7 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
   Future<void> _showAddDailyLogDialog(BuildContext context,
       ProductionDailyLogUseCases logUseCases, ProductionOrderModel order,
       UserModel currentUser) async {
+    final appLocalizations = AppLocalizations.of(context)!;
     List<File> logImages = [];
     String? notes;
     int? counterReading;
@@ -1286,6 +1287,7 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
 
   Future<void> _showHandoverDialog(
       BuildContext context, ProductionOrderModel order, UserModel currentUser) async {
+    final appLocalizations = AppLocalizations.of(context)!;
     final userUseCases = Provider.of<UserUseCases>(context, listen: false);
     final handoverUseCases = Provider.of<ShiftHandoverUseCases>(context, listen: false);
     final productionUseCases = Provider.of<ProductionOrderUseCases>(context, listen: false);


### PR DESCRIPTION
## Summary
- add getters for shiftSupervisorFollowUp and addFollowUp
- provide AppLocalizations in daily log and handover dialogs

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fd15a4af8832a945080f25ee2ae8f