### PR TITLE
Update shift handover visibility

### DIFF
--- a/lib/presentation/production/production_order_detail_screen.dart
+++ b/lib/presentation/production/production_order_detail_screen.dart
@@ -489,8 +489,7 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
             const SizedBox(height: 8),
             if ((currentUser.userRoleEnum == UserRole.productionShiftSupervisor &&
                     widget.order.status == ProductionOrderStatus.inProduction &&
-                    _salesOrder != null &&
-                    _salesOrder!.shiftSupervisorUid == currentUser.uid) ||
+                    widget.order.shiftSupervisorUid == currentUser.uid) ||
                 (currentUser.userRoleEnum ==
                         UserRole.moldInstallationSupervisor &&
                     widget.order.currentStage ==


### PR DESCRIPTION
## Summary
- show shift handover button if order's assigned supervisor matches current user

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fd2e95f9c832aa39f8a4fb52071dc