### PR TITLE
Fix AlertDialog layout crash

### DIFF
--- a/lib/presentation/production/production_order_detail_screen.dart
+++ b/lib/presentation/production/production_order_detail_screen.dart
@@ -661,36 +661,34 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
                         SizedBox(height: 8),
                         Text(appLocalizations.attachedImages, style: TextStyle(fontWeight: FontWeight.bold)), // Add to ARB
                         SizedBox(height: 4),
-                        SizedBox(
-                          width: double.maxFinite,
-                          child: Wrap(
-                            spacing: 8.0,
-                            runSpacing: 4.0,
-                            textDirection: TextDirection.rtl,
-                            children: _pickedImages.map((file) {
-                              return Stack(
-                                children: [
-                                  Image.file(file, width: 80, height: 80, fit: BoxFit.cover),
-                                  Positioned(
-                                    right: 0,
-                                    top: 0,
-                                    child: GestureDetector(
-                                      onTap: () {
-                                        setState(() {
-                                          _pickedImages.remove(file);
-                                        });
-                                      },
-                                      child: CircleAvatar(
-                                        radius: 10,
-                                        backgroundColor: Colors.red,
-                                        child: Icon(Icons.close, size: 12, color: Colors.white),
-                                      ),
+                        Wrap(
+                          spacing: 8.0,
+                          runSpacing: 4.0,
+                          textDirection: TextDirection.rtl,
+                          children: _pickedImages.map((file) {
+                            return Stack(
+                              children: [
+                                Image.file(file, width: 80, height: 80, fit: BoxFit.cover),
+                                Positioned(
+                                  right: 0,
+                                  top: 0,
+                                  child: GestureDetector(
+                                    onTap: () {
+                                      setState(() {
+                                        _pickedImages.remove(file);
+                                      });
+                                    },
+                                    child: CircleAvatar(
+                                      radius: 10,
+                                      backgroundColor: Colors.red,
+                                      child: Icon(Icons.close, size: 12, color: Colors.white),
                                     ),
                                   ),
-                                ],
-                              );
-                            }).toList(),
-                          ),
+                                ),
+                              ],
+                            );
+                          }).toList(),
+                        ),
                         ),
                       ],
                     )
@@ -707,7 +705,6 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
                               border: Border.all(color: Colors.grey),
                               borderRadius: BorderRadius.circular(8),
                             ),
-                            width: double.infinity,
                             child: Signature(
                               controller: _signatureController,
                               height: 150,
@@ -1078,7 +1075,6 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
                               border: Border.all(color: Colors.grey),
                               borderRadius: BorderRadius.circular(8),
                             ),
-                            width: double.infinity,
                             child: Signature(
                               controller: _signatureController,
                               height: 150,


### PR DESCRIPTION
## Summary
- remove unconstrained widths in accept/complete stage dialogs
- avoid intrinsic width errors by not using `double.maxFinite` or `double.infinity`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fe52eed74832ab16e4e6859b9688e