### PR TITLE
Fix syntax in production order detail screen

### DIFF
--- a/lib/presentation/production/production_order_detail_screen.dart
+++ b/lib/presentation/production/production_order_detail_screen.dart
@@ -514,7 +514,7 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
           ],
         ),
       ),
-      ), );
+    );
   }
 
   Widget _buildDetailRow(String label, String value,
@@ -688,7 +688,6 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
                               ],
                             );
                           }).toList(),
-                        ),
                         ),
                       ],
                     )
@@ -1392,4 +1391,5 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
       print('Error uploading file: $e');
       return null;
     }
-  }}
+  }
+}


### PR DESCRIPTION
## Summary
- fix misplaced closing parentheses in `ProductionOrderDetailScreen`
- remove an extra closing brace and add final class brace

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fe6b19480832a90eafd6ba79862f7