### PR TITLE
Fix closing parenthesis in production order detail screen

### DIFF
--- a/lib/presentation/production/production_order_detail_screen.dart
+++ b/lib/presentation/production/production_order_detail_screen.dart
@@ -514,7 +514,8 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
           ],
         ),
       ),
-    );
+    ),
+  );
   }
 
   Widget _buildDetailRow(String label, String value,


### PR DESCRIPTION
## Summary
- fix unmatched closing parentheses in `ProductionOrderDetailScreen`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fe850f7a0832a8a54dfe0c58b3108