### PR TITLE
Fix AlertDialog layout issue

### DIFF
--- a/lib/presentation/production/production_order_detail_screen.dart
+++ b/lib/presentation/production/production_order_detail_screen.dart
@@ -708,6 +708,7 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
                             child: Signature(
                               controller: _signatureController,
                               height: 150,
+                              width: MediaQuery.of(context).size.width,
                               backgroundColor: Colors.grey[100]!,
                             ),
                           ),
@@ -1078,6 +1079,7 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
                             child: Signature(
                               controller: _signatureController,
                               height: 150,
+                              width: MediaQuery.of(context).size.width,
                               backgroundColor: Colors.grey[100]!,
                             ),
                           ),


### PR DESCRIPTION
## Summary
- specify width for signature input widgets in `production_order_detail_screen.dart` so that AlertDialog does not attempt to measure intrinsic dimensions when LayoutBuilder is used internally by the Signature widget

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fea0c2a98832a917a739bf9d4b743