### PR TITLE
Implement handover receipt flow

### DIFF
--- a/lib/data/datasources/shift_handover_datasource.dart
+++ b/lib/data/datasources/shift_handover_datasource.dart
@@ -15,7 +15,16 @@ class ShiftHandoverDatasource {
             .toList());
   }
 
-  Future<void> addHandover(ShiftHandoverModel handover) async {
-    await _firestore.collection('shift_handovers').add(handover.toMap());
+  Future<String> addHandover(ShiftHandoverModel handover) async {
+    final doc = await _firestore.collection('shift_handovers').add(handover.toMap());
+    await doc.update({'id': doc.id});
+    return doc.id;
+  }
+
+  Future<void> updateHandover(ShiftHandoverModel handover) async {
+    await _firestore
+        .collection('shift_handovers')
+        .doc(handover.id)
+        .update(handover.toMap());
   }
 }

--- a/lib/data/models/shift_handover_model.dart
+++ b/lib/data/models/shift_handover_model.dart
@@ -9,7 +9,10 @@ class ShiftHandoverModel {
   final String toSupervisorName;
   final double meterReading;
   final String? notes;
+  final double? receivingMeterReading;
+  final String? receivingNotes;
   final Timestamp createdAt;
+  final Timestamp? receivedAt;
 
   ShiftHandoverModel({
     required this.id,
@@ -20,7 +23,10 @@ class ShiftHandoverModel {
     required this.toSupervisorName,
     required this.meterReading,
     this.notes,
+    this.receivingMeterReading,
+    this.receivingNotes,
     required this.createdAt,
+    this.receivedAt,
   });
 
   factory ShiftHandoverModel.fromDocumentSnapshot(DocumentSnapshot doc) {
@@ -34,7 +40,11 @@ class ShiftHandoverModel {
       toSupervisorName: data['toSupervisorName'] ?? '',
       meterReading: (data['meterReading'] as num?)?.toDouble() ?? 0.0,
       notes: data['notes'],
+      receivingMeterReading:
+          (data['receivingMeterReading'] as num?)?.toDouble(),
+      receivingNotes: data['receivingNotes'],
       createdAt: data['createdAt'] ?? Timestamp.now(),
+      receivedAt: data['receivedAt'] as Timestamp?,
     );
   }
 
@@ -47,7 +57,10 @@ class ShiftHandoverModel {
       'toSupervisorName': toSupervisorName,
       'meterReading': meterReading,
       'notes': notes,
+      'receivingMeterReading': receivingMeterReading,
+      'receivingNotes': receivingNotes,
       'createdAt': createdAt,
+      'receivedAt': receivedAt,
     };
   }
 
@@ -60,7 +73,10 @@ class ShiftHandoverModel {
     String? toSupervisorName,
     double? meterReading,
     String? notes,
+    double? receivingMeterReading,
+    String? receivingNotes,
     Timestamp? createdAt,
+    Timestamp? receivedAt,
   }) {
     return ShiftHandoverModel(
       id: id ?? this.id,
@@ -71,7 +87,11 @@ class ShiftHandoverModel {
       toSupervisorName: toSupervisorName ?? this.toSupervisorName,
       meterReading: meterReading ?? this.meterReading,
       notes: notes ?? this.notes,
+      receivingMeterReading:
+          receivingMeterReading ?? this.receivingMeterReading,
+      receivingNotes: receivingNotes ?? this.receivingNotes,
       createdAt: createdAt ?? this.createdAt,
+      receivedAt: receivedAt ?? this.receivedAt,
     );
   }
 }

--- a/lib/data/repositories/shift_handover_repository_impl.dart
+++ b/lib/data/repositories/shift_handover_repository_impl.dart
@@ -12,7 +12,12 @@ class ShiftHandoverRepositoryImpl implements ShiftHandoverRepository {
   }
 
   @override
-  Future<void> addHandover(ShiftHandoverModel handover) {
+  Future<String> addHandover(ShiftHandoverModel handover) {
     return datasource.addHandover(handover);
+  }
+
+  @override
+  Future<void> updateHandover(ShiftHandoverModel handover) {
+    return datasource.updateHandover(handover);
   }
 }

--- a/lib/domain/repositories/shift_handover_repository.dart
+++ b/lib/domain/repositories/shift_handover_repository.dart
@@ -2,5 +2,6 @@ import 'package:plastic_factory_management/data/models/shift_handover_model.dart
 
 abstract class ShiftHandoverRepository {
   Stream<List<ShiftHandoverModel>> getHandoversForOrder(String orderId);
-  Future<void> addHandover(ShiftHandoverModel handover);
+  Future<String> addHandover(ShiftHandoverModel handover);
+  Future<void> updateHandover(ShiftHandoverModel handover);
 }

--- a/lib/domain/usecases/shift_handover_usecases.dart
+++ b/lib/domain/usecases/shift_handover_usecases.dart
@@ -12,7 +12,7 @@ class ShiftHandoverUseCases {
     return repository.getHandoversForOrder(orderId);
   }
 
-  Future<void> addHandover({
+  Future<String> addHandover({
     required String orderId,
     required UserModel fromSupervisor,
     required UserModel toSupervisor,
@@ -30,6 +30,20 @@ class ShiftHandoverUseCases {
       notes: notes,
       createdAt: Timestamp.now(),
     );
-    await repository.addHandover(handover);
+    final id = await repository.addHandover(handover);
+    return id;
+  }
+
+  Future<void> receiveHandover({
+    required ShiftHandoverModel handover,
+    required double meterReading,
+    String? notes,
+  }) async {
+    final updated = handover.copyWith(
+      receivingMeterReading: meterReading,
+      receivingNotes: notes,
+      receivedAt: Timestamp.now(),
+    );
+    await repository.updateHandover(updated);
   }
 }

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -539,5 +539,6 @@
   "fileImportedSuccessfully": "تم استيراد الملف بنجاح",
   "mapColumnsTitle": "تعيين أعمدة إكسل",
   "selectColumnForField": "اختر العمود لحقل {field}",
-  "importAction": "استيراد"
+  "importAction": "استيراد",
+  "receiveOrder": "استلام الطلب"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -549,5 +549,6 @@
   "fileImportedSuccessfully": "File imported successfully",
   "mapColumnsTitle": "Map Excel Columns",
   "selectColumnForField": "Select column for {field}",
-  "importAction": "Import"
+  "importAction": "Import",
+  "receiveOrder": "Receive Order"
 }

--- a/lib/presentation/production/production_order_detail_screen.dart
+++ b/lib/presentation/production/production_order_detail_screen.dart
@@ -483,8 +483,23 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
                             Text('قراءة العداد: ${h.meterReading}'),
                             if (h.notes != null && h.notes!.isNotEmpty)
                               Text(h.notes!),
+                            if (h.receivingMeterReading != null)
+                              Text('قراءة الاستلام: ${h.receivingMeterReading}'),
+                            if (h.receivingNotes != null &&
+                                h.receivingNotes!.isNotEmpty)
+                              Text(h.receivingNotes!),
                             Text(intl.DateFormat('yyyy-MM-dd HH:mm')
                                 .format(h.createdAt.toDate())),
+                            if (h.receivedAt != null)
+                              Text(intl.DateFormat('yyyy-MM-dd HH:mm')
+                                  .format(h.receivedAt!.toDate())),
+                            if (h.receivedAt == null &&
+                                h.toSupervisorUid == currentUser.uid)
+                              TextButton(
+                                onPressed: () => _showReceiveHandoverDialog(
+                                    context, h, currentUser),
+                                child: Text(AppLocalizations.of(context)!.receiveOrder),
+                              ),
                           ],
                         ),
                       ),
@@ -1234,6 +1249,73 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
                           );
                         },
                   child: Text(appLocalizations.save),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Future<void> _showReceiveHandoverDialog(
+      BuildContext context, ShiftHandoverModel handover, UserModel currentUser) async {
+    String? notes;
+    double? meter;
+
+    await showDialog(
+      context: context,
+      builder: (dialogContext) {
+        return StatefulBuilder(
+          builder: (context, setState) {
+            return AlertDialog(
+              title: Text(AppLocalizations.of(context)!.receiveOrder),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextField(
+                    keyboardType: TextInputType.number,
+                    onChanged: (v) => meter = double.tryParse(v),
+                    decoration: const InputDecoration(
+                      labelText: 'قراءة العداد',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  TextField(
+                    onChanged: (v) => notes = v,
+                    decoration: const InputDecoration(
+                      labelText: 'ملاحظات',
+                      border: OutlineInputBorder(),
+                    ),
+                    maxLines: 3,
+                    textAlign: TextAlign.right,
+                    textDirection: TextDirection.rtl,
+                  ),
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(dialogContext).pop(),
+                  child: Text(AppLocalizations.of(context)!.cancel),
+                ),
+                ElevatedButton(
+                  onPressed: meter == null
+                      ? null
+                      : () async {
+                          Navigator.of(dialogContext).pop();
+                          final useCases =
+                              Provider.of<ShiftHandoverUseCases>(context, listen: false);
+                          await useCases.receiveHandover(
+                            handover: handover,
+                            meterReading: meter!,
+                            notes: notes,
+                          );
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(content: Text(AppLocalizations.of(context)!.save)),
+                          );
+                        },
+                  child: Text(AppLocalizations.of(context)!.save),
                 ),
               ],
             );


### PR DESCRIPTION
## Summary
- extend `ShiftHandoverModel` with receipt fields
- allow updating handovers in datasource and repository
- support saving receipt using `ShiftHandoverUseCases`
- display and accept handover receipt in production and sales order details
- add `receiveOrder` l10n strings

## Testing
- `flutter gen-l10n` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68723f46d1dc832aa468c51608d6dbe7