### PR TITLE
Fix missing receiveOrder localization getter

### DIFF
--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -537,6 +537,7 @@ class AppLocalizations {
   String get rootCauseAnalysis => _strings["rootCauseAnalysis"] ?? "rootCauseAnalysis";
   String get openRootCauseAnalysis => _strings["openRootCauseAnalysis"] ?? "openRootCauseAnalysis";
   String get totalOrders => _strings["totalOrders"] ?? "totalOrders";
+  String get receiveOrder => _strings["receiveOrder"] ?? "receiveOrder";
 
 
 }


### PR DESCRIPTION
## Summary
- add the `receiveOrder` getter to the generated localization class

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6872414aed04832a8fd8fd91a394249a