### PR TITLE
Fix shift supervisor handover dialog

### DIFF
--- a/lib/presentation/production/production_order_detail_screen.dart
+++ b/lib/presentation/production/production_order_detail_screen.dart
@@ -173,7 +173,7 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
     }
     if (currentUser.userRoleEnum == UserRole.moldInstallationSupervisor && currentActiveStage.stageName == 'استلام مشرف تركيب القوالب' && currentActiveStage.status == 'accepted') {
       return ElevatedButton(
-        onPressed: () => _showCompleteStageDialog(context, order, 'تركيب القالب', currentUser, useCases, false, false, true, true),
+        onPressed: () => _showHandoverDialog(context, order, currentUser),
         child: Text(appLocalizations.handoverToShiftSupervisor),
       );
     }


### PR DESCRIPTION
## Summary
- show the shift handover dialog when mold supervisor hands the order to the shift supervisor

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687245b6b628832abccb38e48c577f8c