### PR TITLE
Limit handover receive button

### DIFF
--- a/lib/presentation/production/production_order_detail_screen.dart
+++ b/lib/presentation/production/production_order_detail_screen.dart
@@ -494,7 +494,8 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
                               Text(intl.DateFormat('yyyy-MM-dd HH:mm')
                                   .format(h.receivedAt!.toDate())),
                             if (h.receivedAt == null &&
-                                h.toSupervisorUid == currentUser.uid)
+                                h.toSupervisorUid == currentUser.uid &&
+                                widget.order.shiftSupervisorUid == currentUser.uid)
                               TextButton(
                                 onPressed: () => _showReceiveHandoverDialog(
                                     context, h, currentUser),

--- a/lib/presentation/sales/sales_order_detail_page.dart
+++ b/lib/presentation/sales/sales_order_detail_page.dart
@@ -191,7 +191,8 @@ class _SalesOrderDetailPageState extends State<SalesOrderDetailPage> {
                                   Text(intl.DateFormat('yyyy-MM-dd HH:mm').format(h.receivedAt!.toDate())),
                                 if (h.receivedAt == null &&
                                     currentUser != null &&
-                                    h.toSupervisorUid == currentUser.uid)
+                                    h.toSupervisorUid == currentUser.uid &&
+                                    widget.order.shiftSupervisorUid == currentUser.uid)
                                   TextButton(
                                     onPressed: () => _showReceiveHandoverDialog(
                                         context, h, currentUser),


### PR DESCRIPTION
## Summary
- only show the receive handover button when the logged in supervisor matches the order's assigned supervisor

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68724721f0b4832a9cbac3ada1ca9a81