### PR TITLE
Make shift handover notes and images optional

### DIFF
--- a/lib/data/models/shift_handover_model.dart
+++ b/lib/data/models/shift_handover_model.dart
@@ -11,6 +11,7 @@ class ShiftHandoverModel {
   final String? notes;
   final double? receivingMeterReading;
   final String? receivingNotes;
+  final List<String> receivingImageUrls;
   final Timestamp createdAt;
   final Timestamp? receivedAt;
 
@@ -25,6 +26,7 @@ class ShiftHandoverModel {
     this.notes,
     this.receivingMeterReading,
     this.receivingNotes,
+    this.receivingImageUrls = const [],
     required this.createdAt,
     this.receivedAt,
   });
@@ -43,6 +45,7 @@ class ShiftHandoverModel {
       receivingMeterReading:
           (data['receivingMeterReading'] as num?)?.toDouble(),
       receivingNotes: data['receivingNotes'],
+      receivingImageUrls: List<String>.from(data['receivingImageUrls'] ?? []),
       createdAt: data['createdAt'] ?? Timestamp.now(),
       receivedAt: data['receivedAt'] as Timestamp?,
     );
@@ -59,6 +62,7 @@ class ShiftHandoverModel {
       'notes': notes,
       'receivingMeterReading': receivingMeterReading,
       'receivingNotes': receivingNotes,
+      'receivingImageUrls': receivingImageUrls,
       'createdAt': createdAt,
       'receivedAt': receivedAt,
     };
@@ -75,6 +79,7 @@ class ShiftHandoverModel {
     String? notes,
     double? receivingMeterReading,
     String? receivingNotes,
+    List<String>? receivingImageUrls,
     Timestamp? createdAt,
     Timestamp? receivedAt,
   }) {
@@ -90,6 +95,7 @@ class ShiftHandoverModel {
       receivingMeterReading:
           receivingMeterReading ?? this.receivingMeterReading,
       receivingNotes: receivingNotes ?? this.receivingNotes,
+      receivingImageUrls: receivingImageUrls ?? this.receivingImageUrls,
       createdAt: createdAt ?? this.createdAt,
       receivedAt: receivedAt ?? this.receivedAt,
     );

--- a/lib/domain/usecases/shift_handover_usecases.dart
+++ b/lib/domain/usecases/shift_handover_usecases.dart
@@ -1,10 +1,14 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'dart:io';
+
 import 'package:plastic_factory_management/data/models/shift_handover_model.dart';
 import 'package:plastic_factory_management/data/models/user_model.dart';
 import 'package:plastic_factory_management/domain/repositories/shift_handover_repository.dart';
+import 'package:plastic_factory_management/core/services/file_upload_service.dart';
 
 class ShiftHandoverUseCases {
   final ShiftHandoverRepository repository;
+  final FileUploadService _uploadService = FileUploadService();
 
   ShiftHandoverUseCases(this.repository);
 
@@ -38,10 +42,23 @@ class ShiftHandoverUseCases {
     required ShiftHandoverModel handover,
     required double meterReading,
     String? notes,
+    List<File>? images,
   }) async {
+    List<String> urls = [];
+    if (images != null && images.isNotEmpty) {
+      for (final file in images) {
+        final url = await _uploadService.uploadFile(
+          file,
+          'handover_receiving/${handover.id}_${DateTime.now().microsecondsSinceEpoch}.jpg',
+        );
+        if (url != null) urls.add(url);
+      }
+    }
+
     final updated = handover.copyWith(
       receivingMeterReading: meterReading,
       receivingNotes: notes,
+      receivingImageUrls: [...handover.receivingImageUrls, ...urls],
       receivedAt: Timestamp.now(),
     );
     await repository.updateHandover(updated);

--- a/lib/presentation/production/production_order_detail_screen.dart
+++ b/lib/presentation/production/production_order_detail_screen.dart
@@ -488,6 +488,14 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
                             if (h.receivingNotes != null &&
                                 h.receivingNotes!.isNotEmpty)
                               Text(h.receivingNotes!),
+                            if (h.receivingImageUrls.isNotEmpty)
+                              Wrap(
+                                spacing: 8,
+                                runSpacing: 4,
+                                children: h.receivingImageUrls
+                                    .map((u) => Image.network(u, width: 60, height: 60))
+                                    .toList(),
+                              ),
                             Text(intl.DateFormat('yyyy-MM-dd HH:mm')
                                 .format(h.createdAt.toDate())),
                             if (h.receivedAt != null)
@@ -1263,6 +1271,8 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
       BuildContext context, ShiftHandoverModel handover, UserModel currentUser) async {
     String? notes;
     double? meter;
+    List<File> images = [];
+    final ImagePicker picker = ImagePicker();
 
     await showDialog(
       context: context,
@@ -1293,6 +1303,42 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
                     textAlign: TextAlign.right,
                     textDirection: TextDirection.rtl,
                   ),
+                  const SizedBox(height: 8),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceAround,
+                    children: [
+                      ElevatedButton.icon(
+                        onPressed: () async {
+                          final picked = await picker.pickImage(source: ImageSource.camera);
+                          if (picked != null) {
+                            setState(() => images.add(File(picked.path)));
+                          }
+                        },
+                        icon: const Icon(Icons.camera_alt),
+                        label: const Text('كاميرا'),
+                      ),
+                      ElevatedButton.icon(
+                        onPressed: () async {
+                          final picked = await picker.pickImage(source: ImageSource.gallery);
+                          if (picked != null) {
+                            setState(() => images.add(File(picked.path)));
+                          }
+                        },
+                        icon: const Icon(Icons.photo_library),
+                        label: const Text('معرض'),
+                      ),
+                    ],
+                  ),
+                  if (images.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8.0),
+                      child: Wrap(
+                        spacing: 8,
+                        runSpacing: 4,
+                        children:
+                            images.map((f) => Image.file(f, width: 60, height: 60)).toList(),
+                      ),
+                    ),
                 ],
               ),
               actions: [
@@ -1311,6 +1357,7 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
                             handover: handover,
                             meterReading: meter!,
                             notes: notes,
+                            images: images,
                           );
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(content: Text(AppLocalizations.of(context)!.save)),

--- a/lib/presentation/sales/sales_order_detail_page.dart
+++ b/lib/presentation/sales/sales_order_detail_page.dart
@@ -1,6 +1,9 @@
 // plastic_factory_management/lib/presentation/sales/sales_order_detail_page.dart
 
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:plastic_factory_management/l10n/app_localizations.dart';
 import 'package:plastic_factory_management/data/models/sales_order_model.dart';
 import 'package:intl/intl.dart' as intl;
@@ -186,6 +189,14 @@ class _SalesOrderDetailPageState extends State<SalesOrderDetailPage> {
                                   Text('قراءة الاستلام: ${h.receivingMeterReading}'),
                                 if (h.receivingNotes != null && h.receivingNotes!.isNotEmpty)
                                   Text(h.receivingNotes!),
+                                if (h.receivingImageUrls.isNotEmpty)
+                                  Wrap(
+                                    spacing: 8,
+                                    runSpacing: 4,
+                                    children: h.receivingImageUrls
+                                        .map((u) => Image.network(u, width: 60, height: 60))
+                                        .toList(),
+                                  ),
                                 Text(intl.DateFormat('yyyy-MM-dd HH:mm').format(h.createdAt.toDate())),
                                 if (h.receivedAt != null)
                                   Text(intl.DateFormat('yyyy-MM-dd HH:mm').format(h.receivedAt!.toDate())),
@@ -436,6 +447,8 @@ class _SalesOrderDetailPageState extends State<SalesOrderDetailPage> {
       BuildContext context, ShiftHandoverModel handover, UserModel currentUser) async {
     String? notes;
     double? meter;
+    List<File> images = [];
+    final ImagePicker picker = ImagePicker();
 
     await showDialog(
       context: context,
@@ -466,6 +479,42 @@ class _SalesOrderDetailPageState extends State<SalesOrderDetailPage> {
                     textAlign: TextAlign.right,
                     textDirection: TextDirection.rtl,
                   ),
+                  const SizedBox(height: 8),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceAround,
+                    children: [
+                      ElevatedButton.icon(
+                        onPressed: () async {
+                          final picked = await picker.pickImage(source: ImageSource.camera);
+                          if (picked != null) {
+                            setState(() => images.add(File(picked.path)));
+                          }
+                        },
+                        icon: const Icon(Icons.camera_alt),
+                        label: const Text('كاميرا'),
+                      ),
+                      ElevatedButton.icon(
+                        onPressed: () async {
+                          final picked = await picker.pickImage(source: ImageSource.gallery);
+                          if (picked != null) {
+                            setState(() => images.add(File(picked.path)));
+                          }
+                        },
+                        icon: const Icon(Icons.photo_library),
+                        label: const Text('معرض'),
+                      ),
+                    ],
+                  ),
+                  if (images.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8.0),
+                      child: Wrap(
+                        spacing: 8,
+                        runSpacing: 4,
+                        children:
+                            images.map((f) => Image.file(f, width: 60, height: 60)).toList(),
+                      ),
+                    ),
                 ],
               ),
               actions: [
@@ -484,6 +533,7 @@ class _SalesOrderDetailPageState extends State<SalesOrderDetailPage> {
                             handover: handover,
                             meterReading: meter!,
                             notes: notes,
+                            images: images,
                           );
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(content: Text(AppLocalizations.of(context)!.save)),


### PR DESCRIPTION
## Summary
- support storing image attachments when a shift handover is received
- upload optional images from receive handover dialogs
- show received images inside order details

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687249b3b5ec832abfbb7987bf2b43fc