### PR TITLE
Fix meter reading dialog state

### DIFF
--- a/lib/presentation/production/production_order_detail_screen.dart
+++ b/lib/presentation/production/production_order_detail_screen.dart
@@ -1215,7 +1215,7 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
                     const SizedBox(height: 8),
                     TextField(
                       keyboardType: TextInputType.number,
-                      onChanged: (v) => meter = double.tryParse(v),
+                      onChanged: (v) => setState(() => meter = double.tryParse(v)),
                       decoration: const InputDecoration(
                         labelText: 'قراءة العداد',
                         border: OutlineInputBorder(),
@@ -1286,7 +1286,7 @@ class _ProductionOrderDetailScreenState extends State<ProductionOrderDetailScree
                 children: [
                   TextField(
                     keyboardType: TextInputType.number,
-                    onChanged: (v) => meter = double.tryParse(v),
+                    onChanged: (v) => setState(() => meter = double.tryParse(v)),
                     decoration: const InputDecoration(
                       labelText: 'قراءة العداد',
                       border: OutlineInputBorder(),

--- a/lib/presentation/sales/sales_order_detail_page.dart
+++ b/lib/presentation/sales/sales_order_detail_page.dart
@@ -391,7 +391,7 @@ class _SalesOrderDetailPageState extends State<SalesOrderDetailPage> {
                     const SizedBox(height: 8),
                     TextField(
                       keyboardType: TextInputType.number,
-                      onChanged: (v) => meter = double.tryParse(v),
+                      onChanged: (v) => setState(() => meter = double.tryParse(v)),
                       decoration: InputDecoration(
                         labelText: AppLocalizations.of(context)!.meterReading,
                         border: const OutlineInputBorder(),
@@ -462,7 +462,7 @@ class _SalesOrderDetailPageState extends State<SalesOrderDetailPage> {
                 children: [
                   TextField(
                     keyboardType: TextInputType.number,
-                    onChanged: (v) => meter = double.tryParse(v),
+                    onChanged: (v) => setState(() => meter = double.tryParse(v)),
                     decoration: InputDecoration(
                       labelText: AppLocalizations.of(context)!.meterReading,
                       border: const OutlineInputBorder(),


### PR DESCRIPTION
## Summary
- make meter reading input update dialog state when shifting hands over

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68724c5a9d4c832abca0fd15eda7c140