### PR TITLE
Set status to inProduction on initial shift assignment

### DIFF
--- a/lib/domain/usecases/production_order_usecases.dart
+++ b/lib/domain/usecases/production_order_usecases.dart
@@ -603,6 +603,9 @@ class ProductionOrderUseCases {
     final updated = order.copyWith(
       shiftSupervisorUid: supervisor.uid,
       shiftSupervisorName: supervisor.name,
+      status: order.status == ProductionOrderStatus.inProduction
+          ? order.status
+          : ProductionOrderStatus.inProduction,
     );
     await repository.updateProductionOrder(updated);
 


### PR DESCRIPTION
## Summary
- update `updateShiftSupervisor` usecase so that assigning a shift supervisor automatically changes the order status to `inProduction`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687250d7f120832ab4dcfd296da9b81c